### PR TITLE
chore: configure release-please for dev→main workflow (AB#0)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build & Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -23,6 +23,7 @@ jobs:
         id: release
         with:
           release-type: simple
+          target-branch: main
 
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Updates build.yaml to run release-please on dev branch pushes and create release PRs targeting main instead of releasing directly from main.