### PR TITLE
fix: enable release-please to run on both dev and main (AB#0)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') && github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -23,7 +23,7 @@ jobs:
         id: release
         with:
           release-type: simple
-          target-branch: main
+          target-branch: ${{ github.ref == 'refs/heads/dev' && 'main' || '' }}
 
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Fixes release stage being skipped. Release-please now runs on both dev (to create release PRs) and main (to create actual releases when the PR is merged).