### PR TITLE
fix: correct release-please to check refs/heads/main (AB#0)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -23,7 +23,6 @@ jobs:
         id: release
         with:
           release-type: simple
-          target-branch: main
 
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Fix the release-please workflow to run on main branch instead of dev.

Changes:
- Change condition from refs/heads/dev to refs/heads/main
- Remove unused target-branch parameter

This allows release-please to create release PRs when commits with conventional commit prefixes (fix:/feat:/chore:) land on main.