### PR TITLE
fix: add id-token and attestations permissions for build provenance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   release-please:


### PR DESCRIPTION
The attestation step was failing with \Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable\ because the workflow was missing required permissions.

Adds \id-token: write\ and \ttestations: write\ to the top-level permissions block.