### PR TITLE
fix: use pull_request_target for title checks and sync manifest version

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,7 +1,7 @@
 name: PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:

--- a/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
+++ b/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap uap3 rescap">
-  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.4.1.0" />
+  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.5.1.0" />
   <Properties>
     <DisplayName>Bitwarden Command Palette Extension (Dev)</DisplayName>
     <PublisherDisplayName>Hoobi</PublisherDisplayName>


### PR DESCRIPTION
Two fixes:

**PR Title Check**: Switch from `pull_request`to `pull_request_target` so the check runs on release-please PRs. GitHub does not trigger `pull_request` events for PRs opened by `GITHUB_TOKEN` (bot PRs), so the check was never running — leaving the required status missing.

**Manifest Version**: `Package.appxmanifest` was at `1.4.1.0` while release-please tracks the version as `1.5.1`. release-please uses a substring match to find the old version and replace it, so it silently skipped the file. Updated to `1.5.1.0` so future release PRs will correctly update it (e.g. `1.5.1` → `1.5.2` → `1.5.2.0`).