### PR TITLE
fix: move attestation to release job and fix release-please title check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,7 @@ jobs:
         id: release
         with:
           release-type: simple
+          token: ${{ secrets.GH_PAT }}
 
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Three fixes:

**Attestation on release only**: Moved `attest-build-provenance` from the `build` job (ran every main push) into the `release` job (gated on `release_created == true`). Also scoped `id-token: write` and `attestations: write` to the `release` job only.

**PR title check on release-please PRs**: Pass `secrets.GH_PAT` to release-please so it creates PRs as a real user rather than `GITHUB_TOKEN`. GitHub does not fire `pull_request`/`pull_request_target` events for PRs created by `GITHUB_TOKEN`, so the title check was never triggered. Requires a `GH_PAT` secret with `contents: write` and `pull-requests: write`.