### PR TITLE
fix: use generic updater for manifest version so release-please updates it correctly

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,8 @@
       "include-component-in-tag": false,
       "extra-files": [
         {
-          "type": "xml",
-          "path": "HoobiBitwardenCommandPaletteExtension/Package.appxmanifest",
-          "xpath": "//*[local-name()='Identity']/@Version"
+          "type": "generic",
+          "path": "HoobiBitwardenCommandPaletteExtension/Package.appxmanifest"
         }
       ]
     }


### PR DESCRIPTION
The `xml` updater with an XPath targeting an attribute node (`@Version`) is silently ignored in release-please v17 — it only updates element text content. Switching to `generic` which does a substring replacement of the version string (e.g. `1.5.1` within `Version="1.5.1.0"`) and correctly produces `Version="1.5.2.0"`.