### PR TITLE
ci: fix pre-release and release jobs skipped on push to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,7 +251,14 @@ jobs:
 
   release:
     needs: [release-please, build_x64, build_arm64, lint-and-test, wack_x64, wack_arm64]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      always()
+      && needs.release-please.outputs.release_created == 'true'
+      && needs.build_x64.result == 'success'
+      && needs.build_arm64.result == 'success'
+      && needs.lint-and-test.result == 'success'
+      && needs.wack_x64.result == 'success'
+      && needs.wack_arm64.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -295,7 +302,15 @@ jobs:
 
   pre-release:
     needs: [release-please, build_x64, build_arm64, lint-and-test]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.release-please.outputs.release_created != 'true'
+    if: >-
+      always()
+      && github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+      && needs.release-please.outputs.release_created != 'true'
+      && needs.release-please.result == 'success'
+      && needs.build_x64.result == 'success'
+      && needs.build_arm64.result == 'success'
+      && needs.lint-and-test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The `pre-release` and `release` jobs were silently skipped on every push to main due to GitHub Actions transitive skip propagation. When `detect-changes` is skipped (only runs on PRs), jobs that depend on it (`build_x64`, `build_arm64`, `lint-and-test`) use `always()` to run anyway. However, downstream jobs like `pre-release` and `release` that don't use `always()` inherit the transitive skip from `detect-changes` through the needs chain, even though all their direct dependencies succeeded.

Adds `always()` to both job conditions with explicit `result == 'success'` checks on each dependency to prevent unwanted runs on failure/cancellation.