### PR TITLE
ci: use GitHub App token for release-please and run pre-release in RP PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
Updates release automation in one workflow change.

## What changed
- release-please auth now uses a GitHub App installation token generated at runtime via `actions/create-github-app-token@v2`
- pre-release creation now runs during release-please PR builds (`pull_request` with `head_ref == release-please--branches--main`) instead of push builds from that branch
- push trigger branches stay `[main, dev]`
- app id source switched to repo variable: `vars.RELEASE_PLEASE_APP_ID`

## Why
- Removes dependency on long-lived `GH_PAT`
- Keeps pre-release artifact versioning aligned with bumped `version.txt` in the release-please branch
- Reduces trigger surface and aligns pre-release generation with the release-please PR lifecycle

## Required configuration
- Repo variable: `RELEASE_PLEASE_APP_ID` (set)
- Repo secret: `RELEASE_PLEASE_APP_PRIVATE_KEY` (set)