### PR TITLE
fix: strip trailing non-JSON CLI output and harden RunCliAsync json detection

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
@@ -382,6 +382,25 @@ public class BitwardenCliServiceTests
     Assert.Equal("Test", items[0].Name);
   }
 
+  [Fact]
+  public void ExtractJsonArray_EmptyArray_ReturnsEmptyArray()
+  {
+    Assert.Equal("[]", BitwardenCliService.ExtractJsonArray("[]"));
+  }
+
+  [Fact]
+  public void ExtractJsonArray_BracketTextBeforeRealArray_SkipsIt()
+  {
+    var input = "? Master password: [hidden]\n[{\"id\":\"1\"}]";
+    Assert.Equal("[{\"id\":\"1\"}]", BitwardenCliService.ExtractJsonArray(input));
+  }
+
+  [Fact]
+  public void ExtractJsonArray_EmptyString_ReturnsEmpty()
+  {
+    Assert.Equal(string.Empty, BitwardenCliService.ExtractJsonArray(string.Empty));
+  }
+
   // --- ParseItems ---
 
   [Fact]

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -1166,14 +1166,23 @@ internal sealed class BitwardenCliService
         var trimmed = line.Trim();
         if (trimmed.StartsWith('{') || trimmed.StartsWith('['))
         {
+          var candidate = trimmed;
           try
           {
-            JsonNode.Parse(trimmed);
+            JsonNode.Parse(candidate);
+          }
+          catch (System.Text.Json.JsonException)
+          {
+            candidate = trimmed.StartsWith('[') ? ExtractJsonArray(trimmed) : null;
+            if (candidate != null)
+              try { JsonNode.Parse(candidate); } catch (System.Text.Json.JsonException) { candidate = null; }
+          }
+          if (candidate != null)
+          {
             _ = stderrTask.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
             try { process.Kill(true); } catch { }
-            return trimmed;
+            return candidate;
           }
-          catch (System.Text.Json.JsonException) { }
         }
         if (earlyExitText != null && line.Contains(earlyExitText, StringComparison.OrdinalIgnoreCase))
         {
@@ -1259,21 +1268,45 @@ internal sealed class BitwardenCliService
 
   internal static string ExtractJsonArray(string output)
   {
-    var start = output.IndexOf('[');
-    if (start < 0) return output;
+    if (string.IsNullOrEmpty(output)) return output ?? string.Empty;
 
-    var depth = 0;
-    var inString = false;
-    var escape = false;
-    for (var i = start; i < output.Length; i++)
+    var pos = 0;
+    while (pos < output.Length)
     {
-      var c = output[i];
-      if (escape) { escape = false; continue; }
-      if (c == '\\' && inString) { escape = true; continue; }
-      if (c == '"') { inString = !inString; continue; }
-      if (inString) continue;
-      if (c == '[') depth++;
-      else if (c == ']') { depth--; if (depth == 0) { var extracted = output[start..(i + 1)]; if (extracted.Length != output.TrimEnd().Length) DebugLogService.Log("CLI", $"ExtractJsonArray trimmed {output.Length - extracted.Length} trailing chars from CLI output"); return extracted; } }
+      var start = output.IndexOf('[', pos);
+      if (start < 0) return output;
+
+      var depth = 0;
+      var inString = false;
+      var escape = false;
+      var matched = false;
+      for (var i = start; i < output.Length; i++)
+      {
+        var c = output[i];
+        if (escape) { escape = false; continue; }
+        if (c == '\\' && inString) { escape = true; continue; }
+        if (c == '"') { inString = !inString; continue; }
+        if (inString) continue;
+        if (c == '[') depth++;
+        else if (c == ']')
+        {
+          depth--;
+          if (depth == 0)
+          {
+            var extracted = output[start..(i + 1)];
+            if (extracted.Length <= 2 || extracted.Contains('{'))
+            {
+              if (extracted != output.TrimEnd())
+                DebugLogService.Log("CLI", $"ExtractJsonArray trimmed trailing content from CLI output");
+              return extracted;
+            }
+            pos = i + 1;
+            matched = true;
+            break;
+          }
+        }
+      }
+      if (!matched) return output;
     }
 
     return output;


### PR DESCRIPTION
Fixes two issues found via end-user debug log (#88):

**1. CLI stdout contamination causes JSON parse failure**

Some `bw` CLI versions/configurations write the `? Master password:` prompt (or other text) to stdout appended after the JSON array, either on a trailing line, or on the same line as the JSON. This caused two failure modes:

- `ParseItems`/`ParseFolders` receiving raw contaminated output → `JsonReaderException`
- `RunCliAsync` failing to detect valid JSON on a contaminated line, falling back to a full 358K StringBuilder, then returning the whole thing unparsed

Fixes:
- Added `ExtractJsonArray()`: a bracket-depth-aware extractor that finds the first `[` that opens a JSON array (skipping non-array bracket matches like `[hidden]`), strips any surrounding non-JSON text, and validates with a null/empty guard. Applied to both `ParseItems` and `ParseFolders`.
- Hardened `RunCliAsync` to retry with `ExtractJsonArray()` when `JsonNode.Parse` fails on a `[`-starting line, catches the contamination at the source before falling back to the StringBuilder path.

**2. Thundering herd on `GetVaultStatusAsync`**

Multiple concurrent callers each spawned separate `bw status` processes. Added coalescing via `_statusCheckInFlight`, subsequent callers join the in-flight task instead of starting new CLI processes. Uses .NET 9 `System.Threading.Lock`.

8 new tests for `ExtractJsonArray`.