### PR TITLE
fix: resolve race condition in SubmitDeviceVerificationAsync stream handling

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
@@ -342,6 +342,19 @@ public class BitwardenCliServiceTests
     Assert.Equal(4, BitwardenCliService.Relevance(item, "GitHub", regex));
   }
 
+  // --- MaskJsonStringContent ---
+
+  [Theory]
+  [InlineData("{\"key\":\"password123\"}", "{\"···\":\"···········\"}")]
+  [InlineData("{\"a\":1,\"b\":\"secret\"}", "{\"·\":1,\"·\":\"······\"}")]
+  [InlineData("[{\"type\":1}]", "[{\"····\":1}]")]
+  [InlineData("plain text no json", "plain text no json")]
+  [InlineData("{\"esc\":\"val\\\"ue\"}", "{\"···\":\"·······\"}")]
+  public void MaskJsonStringContent_MasksStringValues(string input, string expected)
+  {
+    Assert.Equal(expected, BitwardenCliService.MaskJsonStringContent(input));
+  }
+
   // --- ExtractJsonArray ---
 
   [Fact]

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -1385,14 +1385,30 @@ internal sealed class BitwardenCliService
       DebugLogService.Log("Cache", $"ParseItems exception after {items.Count} items: {ex.GetType().Name}: {ex.Message}");
       if (ex is System.Text.Json.JsonException jsonEx && jsonEx.BytePositionInLine is long pos && pos > 0 && pos < json.Length)
       {
-        var start = (int)Math.Max(0, pos - 60);
-        var end = (int)Math.Min(json.Length, pos + 60);
-        var snippet = json[start..(int)pos] + ">>HERE<<" + json[(int)pos..end];
-        DebugLogService.Log("Cache", $"ParseItems context around error: ...{snippet}...");
+        var start = (int)Math.Max(0, pos - 80);
+        var end = (int)Math.Min(json.Length, pos + 20);
+        var snippet = MaskJsonStringContent(json[start..(int)pos]) + ">>HERE<<" + MaskJsonStringContent(json[(int)pos..end]);
+        DebugLogService.Log("Cache", $"ParseItems structure around error (string values masked): ...{snippet}...");
       }
     }
 
     return items;
+  }
+
+  internal static string MaskJsonStringContent(string json)
+  {
+    var sb = new System.Text.StringBuilder(json.Length);
+    var inString = false;
+    var escape = false;
+    foreach (var c in json)
+    {
+      if (escape) { escape = false; if (inString) sb.Append('·'); else sb.Append(c); continue; }
+      if (c == '\\' && inString) { escape = true; sb.Append('·'); continue; }
+      if (c == '"') { inString = !inString; sb.Append('"'); continue; }
+      if (inString) { sb.Append('·'); continue; }
+      sb.Append(c);
+    }
+    return sb.ToString();
   }
 
   private static BitwardenItem ParseLogin(JsonNode? login, string id, string name, string? notes, DateTime revisionDate, Dictionary<string, CustomField> customFields, bool favorite, string? folderId, string? organizationId, int reprompt)


### PR DESCRIPTION
The SubmitDeviceVerification_Success_SetsSession test was intermittently failing due to a race condition in SubmitDeviceVerificationAsync.

The bug: when checking `existingStdoutTask.IsCompleted`, the code unconditionally issued a new ReadToEndAsync on the stream regardless of whether the task completed because it detected a prompt (Detected == true) or because it read the stream to end (Detected == false). In the latter case the stream is already consumed, so ReadToEndAsync returns empty, losing the session key.

The fix: only start a new ReadToEndAsync when Detected == true (prompt was detected, remaining content is still in the stream). When Detected == false, the task already holds the full stream content — use it directly via Task.FromResult.