### PR TITLE
fix: add volatile to _sessionKey in BitwardenCliService

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -19,7 +19,7 @@ internal sealed class BitwardenCliService
 {
   private readonly BitwardenSettingsManager? _settings;
   private readonly CliProcessFactory _processFactory;
-  private string? _sessionKey;
+  private volatile string? _sessionKey;
   private readonly System.Collections.Concurrent.ConcurrentDictionary<int, ICliProcess> _runningProcesses = new();
   private ICliProcess? _pendingDeviceVerificationProcess;
   private CancellationTokenSource? _pendingDeviceVerificationCts;


### PR DESCRIPTION
Mark _sessionKey as `volatile` to ensure cross-core visibility of writes without requiring a heavier lock.

Closes #111