### PR TITLE
ci: only sign MSIX on releases and pre-releases

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      sign:
+        required: false
+        type: boolean
+        default: false
     secrets:
       SIGNING_CERTIFICATE:
         required: false
@@ -79,7 +83,7 @@ jobs:
           }
 
       - name: Import signing certificate
-        if: ${{ !inputs.skip }}
+        if: ${{ !inputs.skip && inputs.sign }}
         shell: pwsh
         run: |
           $pfxBytes = [Convert]::FromBase64String("${{ secrets.SIGNING_CERTIFICATE }}")
@@ -90,7 +94,7 @@ jobs:
           Remove-Item $pfxPath
 
       - name: Sign MSIX package
-        if: ${{ !inputs.skip }}
+        if: ${{ !inputs.skip && inputs.sign }}
         shell: pwsh
         run: |
           $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter signtool.exe |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -253,6 +253,7 @@ jobs:
     with:
       platform: x64
       skip: ${{ needs.detect-changes.result == 'success' && needs.detect-changes.outputs.code_changed != 'true' }}
+      sign: ${{ (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     secrets: inherit
 
   build_arm64:
@@ -263,6 +264,7 @@ jobs:
     with:
       platform: ARM64
       skip: ${{ needs.detect-changes.result == 'success' && needs.detect-changes.outputs.code_changed != 'true' }}
+      sign: ${{ (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     secrets: inherit
 
   wack_x64:


### PR DESCRIPTION
## Summary
- Adds a `sign` input to the reusable build workflow, gating the certificate import and MSIX signing steps.
- Caller passes `sign: true` only for the release-please PR (pre-release) and pushes to `main` (release). All other PRs (including Dependabot) and `dev` pushes produce unsigned MSIX artifacts and pass.

## Why
Dependabot PRs run with `Secret source: Dependabot` and cannot read regular Actions secrets, so `SIGNING_CERTIFICATE` / `SIGNING_CERTIFICATE_PASSWORD` interpolated as empty strings, making `ConvertTo-SecureString ""` throw and breaking #130 (and every future Dependabot PR).

## Test plan
- [ ] Build jobs succeed on this PR with signing skipped (sign=false).
- [ ] After merge, re-run #130 to confirm Dependabot PRs now pass.
- [ ] Next release-please PR still produces signed pre-release MSIX.
- [ ] Next push to `main` that creates a release still produces signed release MSIX.