### PR TITLE
fix: restore right-click context menu under PowerToys 0.99

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
     {
       "label": "Kill PowerToys",
       "type": "shell",
-      "command": "$pt = Get-Process PowerToys -ErrorAction SilentlyContinue; if ($pt) { $pt.CloseMainWindow() | Out-Null; if (!$pt.WaitForExit(5000)) { $pt | Stop-Process -Force }; Write-Host 'Stopped PowerToys' } else { Write-Host 'PowerToys was not running' }; $ext = Get-Process HoobiBitwardenCommandPaletteExtension -ErrorAction SilentlyContinue; if ($ext) { $ext | Stop-Process -Force; Write-Host 'Stopped extension host' }",
+      "command": "$names = @('PowerToys','Microsoft.CmdPal.UI','HoobiBitwardenCommandPaletteExtension') + ((Get-Process -ErrorAction SilentlyContinue | Where-Object ProcessName -like 'Microsoft.CmdPal.Ext.*' | Select-Object -ExpandProperty ProcessName -Unique)); foreach ($n in ($names | Select-Object -Unique)) { $procs = Get-Process $n -ErrorAction SilentlyContinue; if ($procs) { foreach ($p in $procs) { try { $p.CloseMainWindow() | Out-Null } catch {} }; Start-Sleep -Milliseconds 500; $procs | Where-Object { -not $_.HasExited } | Stop-Process -Force -ErrorAction SilentlyContinue; Write-Host \"Stopped: $n\" } }",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -35,7 +35,7 @@
     {
       "label": "Deploy (Debug x64)",
       "type": "shell",
-      "command": "Add-AppxPackage -Register -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\AppxManifest.xml' -ForceUpdateFromAnyVersion; Write-Host 'Deployed.'",
+      "command": "Copy-Item -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\Assets' -Destination '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\Assets' -Recurse -Force; Add-AppxPackage -Register -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\AppxManifest.xml' -ForceUpdateFromAnyVersion; Write-Host 'Deployed.'",
       "options": {
         "shell": {
           "executable": "powershell.exe",
@@ -64,8 +64,8 @@
     {
       "label": "Build, Kill & Deploy (Debug x64)",
       "dependsOn": [
-        "Build (Debug x64)",
         "Kill PowerToys",
+        "Build (Debug x64)",
         "Deploy (Debug x64)",
         "Start PowerToys"
       ],

--- a/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
@@ -107,6 +107,59 @@ public class VaultItemHelperTests
     Assert.IsNotType<RepromptPage>(cmd);
   }
 
+  // Regression test: PowerToys 0.99 gates right-click context menus on
+  // Command.Name being non-empty. The TrackedInvokable wrapper used to drop
+  // the inner command's Name, which silently disabled right-click on every
+  // vault item. See https://github.com/hoobio/command-palette-bitwarden/issues/140.
+  [Fact]
+  public void GetDefaultCommand_NoReprompt_ForwardsInnerCommandName()
+  {
+    var login = new BitwardenItem
+    {
+      Id = "test-login",
+      Type = BitwardenItemType.Login,
+      Uris = [new ItemUri("https://example.com", UriMatchType.Default)],
+    };
+    var note = new BitwardenItem { Id = "test-note", Type = BitwardenItemType.SecureNote };
+    var ssh = new BitwardenItem
+    {
+      Id = "test-ssh",
+      Type = BitwardenItemType.SshKey,
+      CustomFields = new Dictionary<string, CustomField>
+      {
+        ["host"] = new CustomField("git@github.com", IsHidden: false),
+      },
+    };
+
+    foreach (var cmd in new[]
+    {
+      VaultItemHelper.GetDefaultCommand(login),
+      VaultItemHelper.GetDefaultCommand(note),
+      VaultItemHelper.GetDefaultCommand(ssh),
+    })
+    {
+      Assert.False(string.IsNullOrEmpty(cmd.Name), $"Default command Name was empty for {cmd.GetType().Name}");
+    }
+  }
+
+  [Fact]
+  public void BuildContextItems_NoReprompt_ForwardInnerCommandName()
+  {
+    var item = new BitwardenItem
+    {
+      Id = "test-login",
+      Type = BitwardenItemType.Login,
+      Reprompt = 0,
+      Username = "user@test.com",
+      Password = "secret",
+      TotpSecret = "JBSWY3DPEHPK3PXP",
+      Uris = [new ItemUri("https://example.com", UriMatchType.Default)],
+    };
+    var contextItems = VaultItemHelper.BuildContextItems(item);
+    foreach (var ci in contextItems)
+      Assert.False(string.IsNullOrEmpty(ci.Command?.Name), $"Context item '{ci.Title}' had empty Command.Name");
+  }
+
   [Fact]
   public void BuildContextItems_Login_Reprompt_AllFieldsProtected()
   {

--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -507,12 +507,27 @@ internal static partial class VaultItemHelper
 
   private static TrackedInvokable Track(string itemId, InvokableCommand inner) => new(inner, itemId);
 
-  private sealed partial class TrackedInvokable(InvokableCommand inner, string itemId) : InvokableCommand
+  private sealed partial class TrackedInvokable : InvokableCommand
   {
+    private readonly InvokableCommand _inner;
+    private readonly string _itemId;
+
+    public TrackedInvokable(InvokableCommand inner, string itemId)
+    {
+      _inner = inner;
+      _itemId = itemId;
+
+      // PowerToys 0.99 gates right-click context menus on Command.Name being
+      // non-empty. Forward identity from the wrapped command so the gate passes.
+      Name = inner.Name;
+      Icon = inner.Icon;
+      Id = inner.Id;
+    }
+
     public override ICommandResult Invoke()
     {
-      AccessTracker.Record(itemId);
-      return inner.Invoke();
+      AccessTracker.Record(_itemId);
+      return _inner.Invoke();
     }
   }
 }


### PR DESCRIPTION
## Summary

Restores the right-click vault-item context menu, which has been silently broken for everyone on PowerToys 0.99.0 / 0.99.1.

## Root cause

PowerToys 0.99 introduced [`CanOpenContextMenu`](https://github.com/microsoft/PowerToys/blob/v0.99.1/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs#L88-L95) to fix a separate first-click race ([microsoft/PowerToys#46625](https://github.com/microsoft/PowerToys/issues/46625) / [#46626](https://github.com/microsoft/PowerToys/pull/46626)). The right-click handler now refuses to open the menu until either the synthetic primary command or at least one MoreCommand has a non-empty `Command.Name`.

Our `TrackedInvokable` wrapper (used by every `GetDefaultCommand` and every `BuildContextItems` entry) inherited from toolkit `Command`, whose `Name` defaults to `string.Empty`. It never copied `Name`/`Icon`/`Id` from the wrapped inner command. Result: every primary and every context entry exposed `Command.Name = ""`, the gate evaluated to `false`, and right-click was dropped.

## Changes

- Forward `Name`, `Icon`, `Id` from the inner command in `TrackedInvokable`'s constructor.
- Add regression tests asserting `Command.Name` is non-empty on `GetDefaultCommand` results and on every `BuildContextItems` entry.
- (separate commit) Tighten the VS Code `Build, Kill & Deploy` task: kill `Microsoft.CmdPal.UI` and all `Microsoft.CmdPal.Ext.*` providers (not just `PowerToys.exe`), kill before build (running extensions lock build outputs), and stage `Assets/` into the build output so the loose-file MSIX register has the manifest-referenced icons on disk.

## Testing

- [x] Unit tests added (2 new in VaultItemHelperTests)
- [x] Manual testing with PowerToys 0.99.1: right-click on vault items now opens the context menu immediately
- [x] Existing tests pass (49/49 VaultItemHelperTests)

Closes #140