### PR TITLE
refactor: make TrackedInvokable a real decorator

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -516,18 +516,22 @@ internal static partial class VaultItemHelper
     {
       _inner = inner;
       _itemId = itemId;
-
-      // PowerToys 0.99 gates right-click context menus on Command.Name being
-      // non-empty. Forward identity from the wrapped command so the gate passes.
-      Name = inner.Name;
-      Icon = inner.Icon;
-      Id = inner.Id;
+      _inner.PropChanged += OnInnerPropChanged;
     }
+
+    public override string Name { get => _inner.Name; set => _inner.Name = value; }
+
+    public override string Id { get => _inner.Id; set => _inner.Id = value; }
+
+    public override IconInfo Icon { get => _inner.Icon; set => _inner.Icon = value; }
 
     public override ICommandResult Invoke()
     {
       AccessTracker.Record(_itemId);
       return _inner.Invoke();
     }
+
+    private void OnInnerPropChanged(object sender, IPropChangedEventArgs args)
+        => OnPropertyChanged(args.PropertyName);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #142 #140. Replaces the snapshot-at-construction fix with a proper decorator: `TrackedInvokable` now overrides `Name`/`Id`/`Icon` to delegate to the wrapped command, and forwards `PropChanged` events so observers see live updates if the inner mutates.

## Why

The merged fix copied identity once in the constructor. That works for the inner commands we use today (`OpenUrlCommand`, `AnonymousCommand`, etc., none of which mutate identity post-construction), but it diverges from how the toolkit treats observable properties: setters fire `PropChanged`, and the host re-fetches on those events. A decorator that delegates and re-raises is the contract the wrapped type already implements; no reason for ours to be weaker.

## Changes

- `Name`, `Id`, `Icon` are now overridden getters/setters delegating to `_inner`.
- Subscribe to `_inner.PropChanged` and re-raise via `OnPropertyChanged(args.PropertyName)`.
- Drop the constructor snapshot.

## Testing

- [x] Existing 49 `VaultItemHelperTests` pass against the decorator
- [x] Manual: right-click context menu on vault items works under PowerToys 0.99.1