### PR TITLE
fix: unblock non-code PRs and make Build/Deploy task chain reliable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -259,9 +259,10 @@ jobs:
     needs: [detect-changes]
     # Always run so the required check posts a status even on non-code PRs.
     # Heavy steps gate on env.SHOULD_BUILD; the no-op path posts a notice and
-    # exits 0.
+    # exits 0. Use Linux for the skip path (sub-10s spin-up) and Windows only
+    # when there's an actual MSIX to produce.
     if: always() && needs.detect-changes.result != 'cancelled' && needs.detect-changes.result != 'failure'
-    runs-on: windows-latest
+    runs-on: ${{ (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.code_changed == 'true') && 'windows-latest' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -257,25 +257,41 @@ jobs:
   build-msix:
     name: Build MSIX (${{ matrix.platform }})
     needs: [detect-changes]
-    if: always() && (needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.code_changed == 'true')
+    # Always run so the required check posts a status even on non-code PRs.
+    # Heavy steps gate on env.SHOULD_BUILD; the no-op path posts a notice and
+    # exits 0.
+    if: always() && needs.detect-changes.result != 'cancelled' && needs.detect-changes.result != 'failure'
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         platform: [x64, ARM64]
     env:
+      # True for code-bearing PRs and for non-pull_request events (push/workflow_dispatch/release).
+      SHOULD_BUILD: ${{ needs.detect-changes.result == 'skipped' || needs.detect-changes.outputs.code_changed == 'true' }}
       # Sign on release-please PRs and on main pushes; PRs from contributors stay unsigned.
       SHOULD_SIGN: ${{ (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       HAS_SIGNING_CERT: ${{ secrets.SIGNING_CERTIFICATE != '' && vars.SIGNING_CERT_THUMBPRINT != '' }}
     steps:
+      - name: Skip notice (no code changes)
+        if: env.SHOULD_BUILD != 'true'
+        shell: bash
+        run: |
+          echo "::notice::No code changes; MSIX build skipped for ${{ matrix.platform }}"
+          echo "### 💭 No MSIX build needed (${{ matrix.platform }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "Build was skipped because this PR has no code changes. Reporting success so the required check passes." >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v6
+        if: env.SHOULD_BUILD == 'true'
 
       - uses: actions/setup-dotnet@v5
+        if: env.SHOULD_BUILD == 'true'
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Read version
         id: version
+        if: env.SHOULD_BUILD == 'true'
         shell: pwsh
         run: |
           $ver = (Get-Content version.txt -Raw).Trim()
@@ -283,12 +299,14 @@ jobs:
           "APP_VERSION=$ver" | Out-File -Append $env:GITHUB_ENV
 
       - name: Stamp Package.appxmanifest version
+        if: env.SHOULD_BUILD == 'true'
         uses: hoobio/pipeline-tools/pipeline/github/step/stamp-msix-version@v1.5.0
         with:
           manifest-path: ${{ env.APPXMANIFEST_PATH }}
           version: ${{ steps.version.outputs.version }}
 
       - name: Build MSIX
+        if: env.SHOULD_BUILD == 'true'
         uses: hoobio/pipeline-tools/pipeline/github/step/build-msix-dotnet@v1.5.0
         with:
           project-path: ${{ env.PROJECT_PATH }}
@@ -300,6 +318,7 @@ jobs:
       # Stage it to a flat directory under a consistent name so the signing step,
       # artifact upload, and release attachment all see a clean path.
       - name: Stage MSIX
+        if: env.SHOULD_BUILD == 'true'
         shell: pwsh
         env:
           PLATFORM: ${{ matrix.platform }}
@@ -316,7 +335,7 @@ jobs:
           Write-Host "Staged MSIX: $dest"
 
       - name: Sign MSIX
-        if: env.SHOULD_SIGN == 'true' && env.HAS_SIGNING_CERT == 'true'
+        if: env.SHOULD_BUILD == 'true' && env.SHOULD_SIGN == 'true' && env.HAS_SIGNING_CERT == 'true'
         uses: hoobio/pipeline-tools/pipeline/github/step/sign-msix@v1.5.0
         with:
           pfx-base64: ${{ secrets.SIGNING_CERTIFICATE }}
@@ -325,11 +344,12 @@ jobs:
           packages-path: ${{ github.workspace }}\staging\msix-${{ matrix.platform }}
 
       - name: Skip-sign notice
-        if: env.SHOULD_SIGN != 'true' || env.HAS_SIGNING_CERT != 'true'
+        if: env.SHOULD_BUILD == 'true' && (env.SHOULD_SIGN != 'true' || env.HAS_SIGNING_CERT != 'true')
         shell: bash
         run: echo "::warning::MSIX produced unsigned (SHOULD_SIGN=$SHOULD_SIGN, HAS_SIGNING_CERT=$HAS_SIGNING_CERT)."
 
       - name: Upload MSIX artifact
+        if: env.SHOULD_BUILD == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: msix-${{ matrix.platform }}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
     {
       "label": "Kill PowerToys",
       "type": "shell",
-      "command": "$names = @('PowerToys','Microsoft.CmdPal.UI','HoobiBitwardenCommandPaletteExtension') + ((Get-Process -ErrorAction SilentlyContinue | Where-Object ProcessName -like 'Microsoft.CmdPal.Ext.*' | Select-Object -ExpandProperty ProcessName -Unique)); foreach ($n in ($names | Select-Object -Unique)) { $procs = Get-Process $n -ErrorAction SilentlyContinue; if ($procs) { foreach ($p in $procs) { try { $p.CloseMainWindow() | Out-Null } catch {} }; Start-Sleep -Milliseconds 500; $procs | Where-Object { -not $_.HasExited } | Stop-Process -Force -ErrorAction SilentlyContinue; Write-Host \"Stopped: $n\" } }",
+      "command": "$names = @('PowerToys','Microsoft.CmdPal.UI','HoobiBitwardenCommandPaletteExtension') + ((Get-Process -ErrorAction SilentlyContinue | Where-Object ProcessName -like 'Microsoft.CmdPal.Ext.*' | Select-Object -ExpandProperty ProcessName -Unique)); foreach ($n in ($names | Select-Object -Unique)) { $procs = Get-Process $n -ErrorAction SilentlyContinue; if ($procs) { foreach ($p in $procs) { try { $p.CloseMainWindow() | Out-Null } catch {} }; Start-Sleep -Milliseconds 500; $procs | Where-Object { -not $_.HasExited } | Stop-Process -Force -ErrorAction SilentlyContinue; Write-Host \"Stopped: $n\" } }; exit 0",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -35,7 +35,7 @@
     {
       "label": "Deploy (Debug x64)",
       "type": "shell",
-      "command": "Copy-Item -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\Assets' -Destination '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\Assets' -Recurse -Force; Add-AppxPackage -Register -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\AppxManifest.xml' -ForceUpdateFromAnyVersion; Write-Host 'Deployed.'",
+      "command": "$dst = '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\Assets'; New-Item -ItemType Directory -Path $dst -Force | Out-Null; Copy-Item -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\Assets\\*' -Destination $dst -Recurse -Force; Add-AppxPackage -Register -Path '${workspaceFolder}\\HoobiBitwardenCommandPaletteExtension\\bin\\x64\\Debug\\net10.0-windows10.0.26100.0\\win-x64\\AppxManifest.xml' -ForceUpdateFromAnyVersion; Write-Host 'Deployed.'",
       "options": {
         "shell": {
           "executable": "powershell.exe",


### PR DESCRIPTION
## Summary

Two unrelated reliability fixes that surfaced while testing the PowerToys 0.99 right-click fix.

## 1. VS Code task: make deploy idempotent and tolerate empty kill list

- `Copy-Item -Path src\Assets -Destination dst\Assets -Recurse -Force` with an existing destination directory copies the source folder INTO the destination, nesting as `Assets/Assets/Assets/...` on every re-run. Switched to a contents glob (`Assets\*`) into a `New-Item -Force`-ensured destination, which is idempotent.
- The Kill task could exit non-zero (inheriting `$LASTEXITCODE` from the last external invocation) and abort the `dependsOrder: sequence` chain even when nothing was wrong. Appended `; exit 0` so the kill phase always reports success when it completes without throwing.

## 2. CI: make Build MSIX always report a status

`Build MSIX (x64)` and `Build MSIX (ARM64)` are required checks but were conditionally skipped on non-code PRs (`.vscode/`-only, docs-only, etc.) by the path-filter gate. A skipped job posts no status, leaving the required check in `Expected — Waiting for status to be reported` forever and blocking merge.

Restructured the job to always run with a `SHOULD_BUILD` env that mirrors the old condition. The no-code path posts a notice + exits 0 so the required check passes cheaply. Downstream jobs (`build-msi`, `wack`, `sbom`, `release`, `pre-release`) all still gate on `code_changed`, so they continue to skip cleanly on non-code PRs.

## Testing

- [x] Ran the new Copy-Item pattern twice in a row. Destination contents flat, no nesting.
- [x] Ran the kill body manually. Exit code 0.
- [x] Full chain (Kill → Build → Deploy → Start) works end-to-end.
- [ ] Required checks now report status on this PR (verified by CI on this commit).