### PR TITLE
fix: null-guard TrackedInvokable PropChanged handler and SKSurface allocation

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -532,6 +532,9 @@ internal static partial class VaultItemHelper
     }
 
     private void OnInnerPropChanged(object sender, IPropChangedEventArgs args)
-        => OnPropertyChanged(args.PropertyName);
+    {
+      if (args?.PropertyName is { } name)
+        OnPropertyChanged(name);
+    }
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Services/SvgRasterizer.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/SvgRasterizer.cs
@@ -29,6 +29,9 @@ internal static class SvgRasterizer
 
             var imageInfo = new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul);
             using var surface = SKSurface.Create(imageInfo);
+            if (surface is null)
+                return null;
+
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
             canvas.Scale(scale);


### PR DESCRIPTION
## Summary

Two null-safety hardening fixes surfaced by a post-v1.7.1 code audit. Prevents avoidable `NullReferenceException`s on the UI thread (PropChanged) and during favicon rasterization under memory pressure (SKSurface allocation failure).

## Changes

- `TrackedInvokable.OnInnerPropChanged`: guard against null `IPropChangedEventArgs` and null `PropertyName` before re-firing on the wrapper. Previously a malformed event from the inner command would throw on the UI thread.
- `SvgRasterizer.TryRasterize`: explicit null check after `SKSurface.Create`. Skia returns null on allocation failure (e.g. GPU exhaustion); the existing broad `catch` would absorb the resulting NRE on every favicon render. Early-return is cheaper and clearer.

## Testing

- [x] Existing tests pass (`dotnet test -p:Platform=x64`): 437/437 passing
- [x] Manual testing with PowerToys Command Palette
- [ ] Unit tests added/updated (defensive guards on existing covered paths; no new branch worth a dedicated test)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
- [x] Changed `.cs` files meet the 50% coverage threshold
- [ ] Wiki docs updated (no behavior change)