### PR TITLE
fix: search debounce and release pipeline immutable-release fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -701,12 +701,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # release-please leaves the release as a draft; the REST endpoint
+          # /releases/tags/{tag} returns 404 for drafts (the tag isn't created
+          # until publish). `gh release view` lists drafts and matches by name,
+          # so we use it to read the current body and `gh release edit` to
+          # rewrite it. The draft flip-to-published happens in the next step.
           TAG="${{ needs.release-please.outputs.tag_name }}"
-          ID=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.id')
-          BODY=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.body // ""')
+          BODY=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body // ""')
           TRUST=$'\n\n---\n> ✅ WACK certified (x64, ARM64) · \U0001F512 [CodeQL scanned](https://github.com/${{ github.repository }}/actions/workflows/codeql.yml)'
-          jq -n --arg body "${BODY}${TRUST}" '{body: $body}' \
-            | gh api --method PATCH "repos/${{ github.repository }}/releases/$ID" --input -
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${TRUST}"
 
       - name: Publish draft release
         uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.5.0
@@ -782,17 +785,31 @@ jobs:
           name: msi-ARM64
           path: release/msi-ARM64
 
-      - name: Create pre-release
+      # Create as a draft so action-gh-release can attach assets. On repos
+      # with "immutable releases" enabled, publishing a release locks its
+      # asset list, and softprops/action-gh-release publishes before
+      # uploading - so non-draft prereleases fail with "Cannot upload asset
+      # ... to an immutable release". Keeping it as a draft lets the upload
+      # complete; the next step flips it to a published prerelease.
+      - name: Create pre-release (draft)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
           name: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
           prerelease: true
+          draft: true
           make_latest: false
           body_path: /tmp/release_notes.txt
           files: |
             release/**/*.msix
             release/**/*.msi
+
+      - name: Publish pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
+        run: |
+          gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false --prerelease
 
       - name: Prune old pre-releases
         env:

--- a/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
@@ -304,29 +304,42 @@ public class VaultItemHelperTests
   {
     RepromptPage.GracePeriodSeconds = 60;
     RepromptPage.ClearGracePeriod();
-    Assert.False(RepromptPage.IsWithinGracePeriod());
+    Assert.False(RepromptPage.IsWithinGracePeriod("item-a"));
 
-    RepromptPage.RecordVerification();
-    Assert.True(RepromptPage.IsWithinGracePeriod());
+    RepromptPage.RecordVerification("item-a");
+    Assert.True(RepromptPage.IsWithinGracePeriod("item-a"));
+  }
+
+  [Fact]
+  public void RepromptGracePeriod_IsScopedToVerifiedItem()
+  {
+    RepromptPage.GracePeriodSeconds = 60;
+    RepromptPage.ClearGracePeriod();
+
+    RepromptPage.RecordVerification("item-a");
+
+    Assert.True(RepromptPage.IsWithinGracePeriod("item-a"));
+    Assert.False(RepromptPage.IsWithinGracePeriod("item-b"));
+    RepromptPage.ClearGracePeriod();
   }
 
   [Fact]
   public void RepromptGracePeriod_ClearGracePeriod_ResetsState()
   {
     RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.RecordVerification();
-    Assert.True(RepromptPage.IsWithinGracePeriod());
+    RepromptPage.RecordVerification("item-a");
+    Assert.True(RepromptPage.IsWithinGracePeriod("item-a"));
 
     RepromptPage.ClearGracePeriod();
-    Assert.False(RepromptPage.IsWithinGracePeriod());
+    Assert.False(RepromptPage.IsWithinGracePeriod("item-a"));
   }
 
   [Fact]
   public void RepromptGracePeriod_ZeroSeconds_AlwaysFalse()
   {
     RepromptPage.GracePeriodSeconds = 0;
-    RepromptPage.RecordVerification();
-    Assert.False(RepromptPage.IsWithinGracePeriod());
+    RepromptPage.RecordVerification("item-a");
+    Assert.False(RepromptPage.IsWithinGracePeriod("item-a"));
     RepromptPage.GracePeriodSeconds = 60;
     RepromptPage.ClearGracePeriod();
   }
@@ -335,7 +348,7 @@ public class VaultItemHelperTests
   public void GetDefaultCommand_WithReprompt_GracePeriod_BypassesReprompt()
   {
     RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.RecordVerification();
+    RepromptPage.RecordVerification("test-1");
     var svc = new BitwardenCliService();
     var item = new BitwardenItem
     {
@@ -350,10 +363,30 @@ public class VaultItemHelperTests
   }
 
   [Fact]
+  public void GetDefaultCommand_GracePeriod_ScopedToItem_OtherItemStillProtected()
+  {
+    RepromptPage.GracePeriodSeconds = 60;
+    RepromptPage.ClearGracePeriod();
+    RepromptPage.RecordVerification("verified-item");
+
+    var svc = new BitwardenCliService();
+    var otherItem = new BitwardenItem
+    {
+      Id = "other-item",
+      Type = BitwardenItemType.Login,
+      Reprompt = 1,
+      Uris = [new ItemUri("https://example.com", UriMatchType.Default)],
+    };
+    var cmd = VaultItemHelper.GetDefaultCommand(otherItem, svc);
+    Assert.IsType<RepromptPage>(cmd);
+    RepromptPage.ClearGracePeriod();
+  }
+
+  [Fact]
   public void BuildContextItems_Login_Reprompt_GracePeriod_BypassesReprompt()
   {
     RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.RecordVerification();
+    RepromptPage.RecordVerification("test-login");
     var svc = new BitwardenCliService();
     var item = new BitwardenItem
     {
@@ -372,67 +405,17 @@ public class VaultItemHelperTests
   }
 
   [Fact]
-  public void RecordVerification_PersistsGraceFile()
+  public void RecordVerification_DoesNotPersistAcrossProcesses()
   {
     RepromptPage.GracePeriodSeconds = 60;
     RepromptPage.ClearGracePeriod();
 
-    RepromptPage.RecordVerification();
-
-    var graceFile = Path.Combine(
-      Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-      "HoobiBitwardenCommandPalette", "grace.json");
-    Assert.True(File.Exists(graceFile));
-    RepromptPage.ClearGracePeriod();
-  }
-
-  [Fact]
-  public void ClearGracePeriod_DeletesGraceFile()
-  {
-    RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.RecordVerification();
-
-    RepromptPage.ClearGracePeriod();
+    RepromptPage.RecordVerification("item-a");
 
     var graceFile = Path.Combine(
       Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
       "HoobiBitwardenCommandPalette", "grace.json");
     Assert.False(File.Exists(graceFile));
-  }
-
-  [Fact]
-  public void IsWithinGracePeriod_ReadsFromDisk_WhenInProcessCacheEmpty()
-  {
-    RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.ClearGracePeriod();
-
-    // Write a fresh grace file directly (simulating a previous process)
-    var graceDir = Path.Combine(
-      Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-      "HoobiBitwardenCommandPalette");
-    Directory.CreateDirectory(graceDir);
-    File.WriteAllText(Path.Combine(graceDir, "grace.json"),
-      $"{{\"verified\":{DateTime.UtcNow.Ticks}}}");
-
-    Assert.True(RepromptPage.IsWithinGracePeriod());
-    RepromptPage.ClearGracePeriod();
-  }
-
-  [Fact]
-  public void IsWithinGracePeriod_ExpiredGraceFile_ReturnsFalse()
-  {
-    RepromptPage.GracePeriodSeconds = 60;
-    RepromptPage.ClearGracePeriod();
-
-    // Write an expired grace file (2 minutes ago)
-    var graceDir = Path.Combine(
-      Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-      "HoobiBitwardenCommandPalette");
-    Directory.CreateDirectory(graceDir);
-    File.WriteAllText(Path.Combine(graceDir, "grace.json"),
-      $"{{\"verified\":{DateTime.UtcNow.AddMinutes(-2).Ticks}}}");
-
-    Assert.False(RepromptPage.IsWithinGracePeriod());
     RepromptPage.ClearGracePeriod();
   }
 

--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.System;
@@ -527,8 +528,14 @@ internal static partial class VaultItemHelper
 
     public override ICommandResult Invoke()
     {
-      AccessTracker.Record(_itemId);
-      return _inner.Invoke();
+      // Run the inner action first so the clipboard write and toast result
+      // are returned to the host before the (relatively slow) access-tracker
+      // file write + UI rebuild fires. Tracking is fire-and-forget on a
+      // worker thread to keep the keyboard-shortcut/context-menu path snappy.
+      var result = _inner.Invoke();
+      var id = _itemId;
+      _ = Task.Run(() => AccessTracker.Record(id));
+      return result;
     }
 
     private void OnInnerPropChanged(object sender, IPropChangedEventArgs args)

--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -32,8 +32,8 @@ internal static partial class VaultItemHelper
 
   internal static ICommand GetDefaultCommand(BitwardenItem item, BitwardenCliService? service = null)
   {
-    if (item.Reprompt == 1 && service != null && !RepromptPage.IsWithinGracePeriod())
-      return new RepromptPage(service, BuildDefaultAction(item), "Open");
+    if (item.Reprompt == 1 && service != null && !RepromptPage.IsWithinGracePeriod(item.Id))
+      return new RepromptPage(service, item.Id, BuildDefaultAction(item), "Open");
 
     return Track(item.Id, item.Type switch
     {
@@ -492,8 +492,8 @@ internal static partial class VaultItemHelper
 
   private static ICommand CopyFieldCommand(string itemId, string text, string label, BitwardenCliService? reprompt, bool isSensitive = false)
   {
-    if (reprompt != null && !RepromptPage.IsWithinGracePeriod())
-      return new RepromptPage(reprompt, () => SecureClipboardService.CopySensitive(text), label);
+    if (reprompt != null && !RepromptPage.IsWithinGracePeriod(itemId))
+      return new RepromptPage(reprompt, itemId, () => SecureClipboardService.CopySensitive(text), label);
     return Track(itemId, isSensitive
       ? CopySensitive(text, label)
       : CopyNonSensitive(text, label));
@@ -501,8 +501,8 @@ internal static partial class VaultItemHelper
 
   private static ICommand SensitiveCommand(string itemId, Action action, string label, BitwardenCliService? reprompt)
   {
-    if (reprompt != null && !RepromptPage.IsWithinGracePeriod())
-      return new RepromptPage(reprompt, action, label);
+    if (reprompt != null && !RepromptPage.IsWithinGracePeriod(itemId))
+      return new RepromptPage(reprompt, itemId, action, label);
     return Track(itemId, new AnonymousCommand(action) { Name = $"Copy {label}", Result = CommandResult.ShowToast($"Copied {label} to clipboard") });
   }
 

--- a/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
+++ b/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap uap3 rescap">
-  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.7.1.0" />
+  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.8.0.0" />
   <Properties>
     <DisplayName>Command Palette Extension for Bitwarden (Dev)</DisplayName>
     <PublisherDisplayName>Hoobi</PublisherDisplayName>

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -136,7 +136,10 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 return _currentItems;
             }
 
-            if (CaptureContext(force: true) && !_handlingAction && _service.LastStatus == VaultStatus.Unlocked && _service.IsCacheLoaded)
+            // Use the throttled capture (default 500ms) so repeated GetItems
+            // calls from the host don't trigger a fresh window enumeration
+            // every time. The first GetItems above already forces a refresh.
+            if (CaptureContext() && !_handlingAction && _service.LastStatus == VaultStatus.Unlocked && _service.IsCacheLoaded)
             {
                 _currentItems = BuildListItems(Search(_currentSearchText));
             }
@@ -153,7 +156,11 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
-        CaptureContext(force: true);
+        // Don't recapture foreground context here. The user is focused on the
+        // palette while typing, so the context can't have changed since the
+        // last GetItems call. CaptureContext does Win32 window enumeration and
+        // a UIA/COM round-trip per browser window, which adds visible lag to
+        // every keystroke.
         _currentSearchText = newSearch;
 
         if (_service.IsUnlocked)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -857,6 +857,10 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 {
                     _biometricClickFailed = true;
                     _errorMessage = error ?? "Windows Hello unlock failed";
+                    // Settle flags before notifying the host (see comment on
+                    // the success path below).
+                    _handlingAction = false;
+                    IsLoading = false;
                     _currentItems = BuildLockedItems();
                     RaiseItemsChanged();
 
@@ -874,11 +878,20 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 HideBiometricStatus();
                 ShowLoadingStatus("Retrieving items from vault...", "bw list items");
                 await _service.RefreshCacheAsync();
+                // Clear handling/loading flags BEFORE raising ItemsChanged so
+                // the host's GetItems callback sees the fully-settled state.
+                // If we raise first and clear in `finally`, the host fetches
+                // items while _handlingAction/IsLoading are still true and
+                // keeps showing the loading placeholder until the next
+                // hide/show cycle forces a fresh GetItems.
+                _handlingAction = false;
+                IsLoading = false;
                 _currentItems = BuildListItems(Search(_currentSearchText));
                 RaiseItemsChanged();
             }
             finally
             {
+                // Defensive: ensure flags are cleared on any exit path.
                 _handlingAction = false;
                 IsLoading = false;
             }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -793,11 +793,38 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     {
         if (_autoBiometricTriggered || _biometricClickFailed || _handlingAction)
             return;
-        if (_settings?.UseDesktopIntegration.Value != true || _settings?.AutoBiometricUnlock.Value != true)
+
+        var biometricEnabled = _settings?.UseDesktopIntegration.Value == true
+                            && _settings?.AutoBiometricUnlock.Value == true;
+        var rememberSession = _settings?.RememberSession.Value == true;
+
+        if (!biometricEnabled && !rememberSession)
             return;
+
         _autoBiometricTriggered = true;
-        DebugLogService.Log("Page", "Auto-triggering biometric unlock");
-        OnBiometricUnlockRequested();
+
+        _ = Task.Run(async () =>
+        {
+            // Prefer silent restore from the saved credential so RememberSession
+            // actually saves the user a prompt after a soft auto-lock.
+            if (rememberSession && await _service.TryRestoreSessionAsync())
+            {
+                DebugLogService.Log("Page", "Restored session silently; biometric not needed");
+                return;
+            }
+
+            if (biometricEnabled)
+            {
+                DebugLogService.Log("Page", "Auto-triggering biometric unlock");
+                OnBiometricUnlockRequested();
+            }
+            else
+            {
+                // RememberSession was on but the stored credential was gone or
+                // invalid; reset so the manual unlock paths work.
+                _autoBiometricTriggered = false;
+            }
+        });
     }
 
     private void HideBiometricStatus()

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -35,6 +35,15 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private Timer? _syncTimer;
     private ListItem? _syncItem;
     private readonly Timer _iconRefreshTimer;
+    private readonly Timer _searchDebounceTimer;
+    // Debounce window for the unlocked-vault search rebuild. Each keystroke
+    // resets the timer; the rebuild only runs after the user pauses for this
+    // long. BuildListItems allocates 5-15 commands per result, so doing it
+    // per keystroke (with no debounce) makes typing feel laggy on larger
+    // vaults. 100ms is the sweet spot used by most palette UIs (VS Code,
+    // Spotlight): below the threshold of perceived input delay, but enough
+    // to collapse a typed word into a single rebuild.
+    private const int SearchDebounceMs = 100;
     private StatusMessage? _lastBiometricStatus;
     private volatile bool _biometricClickFailed;
     private volatile bool _autoBiometricTriggered;
@@ -54,6 +63,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         RepromptPage.GraceStarted += OnRepromptGraceStarted;
         RepromptPage.BiometricRequested += OnRepromptBiometricRequested;
         _iconRefreshTimer = new Timer(OnIconRefreshTick, null, Timeout.Infinite, Timeout.Infinite);
+        _searchDebounceTimer = new Timer(OnSearchDebounceTick, null, Timeout.Infinite, Timeout.Infinite);
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
         var v = Windows.ApplicationModel.Package.Current.Id.Version;
         var version = $"{v.Major}.{v.Minor}.{v.Build}";
@@ -184,8 +194,9 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
 
         if (_service.IsCacheLoaded)
         {
-            _currentItems = BuildListItems(Search(newSearch));
-            RaiseItemsChanged();
+            // Debounce: each keystroke just (re)arms the timer. The actual
+            // rebuild + RaiseItemsChanged runs once the user pauses typing.
+            _searchDebounceTimer.Change(SearchDebounceMs, Timeout.Infinite);
             _service.TriggerBackgroundRefreshIfStale();
         }
         else
@@ -196,6 +207,17 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 await _service.RefreshCacheAsync();
             });
         }
+    }
+
+    private void OnSearchDebounceTick(object? _)
+    {
+        // Re-check state at fire time: the vault may have locked, an action
+        // may be in flight, or the cache may have been invalidated since the
+        // keystroke that armed the timer.
+        if (_handlingAction || _service.LastStatus != VaultStatus.Unlocked || !_service.IsCacheLoaded)
+            return;
+        _currentItems = BuildListItems(Search(_currentSearchText));
+        RaiseItemsChanged();
     }
 
     private void OnCacheUpdated()
@@ -586,6 +608,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _totpTimer?.Dispose();
         _syncTimer?.Dispose();
         _iconRefreshTimer.Dispose();
+        _searchDebounceTimer.Dispose();
         _service.CacheUpdated -= OnCacheUpdated;
         _service.StatusChanged -= OnStatusChanged;
         _service.WarmupCompleted -= OnWarmupCompleted;

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -173,16 +173,6 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
 
         if ((_twoFactorRequired || _deviceVerificationRequired) && !_handlingAction)
         {
-            var code = newSearch.Trim();
-            if (code.Length >= 6 && code.Length <= 8 && long.TryParse(code, out _))
-            {
-                if (_deviceVerificationRequired)
-                    OnDeviceVerificationSubmitted(code);
-                else
-                    OnTwoFactorSubmitted(code);
-                return;
-            }
-
             _currentItems = BuildUnauthenticatedItems();
             RaiseItemsChanged();
             return;
@@ -345,10 +335,17 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         if (_twoFactorRequired && _pendingEmail != null && _pendingPassword != null)
         {
             PlaceholderText = "Enter your 2FA code...";
-            var hint = new ListItem(new NoOpCommand())
+            var code = _currentSearchText.Trim();
+            var canSubmit = code.Length >= 6 && code.Length <= 8 && long.TryParse(code, out _);
+            ICommand command = canSubmit
+                ? new AnonymousCommand(() => OnTwoFactorSubmitted(code)) { Name = "Submit", Result = CommandResult.KeepOpen() }
+                : new NoOpCommand();
+            var hint = new ListItem(command)
             {
-                Title = "Two-Factor Authentication Required",
-                Subtitle = _errorMessage ?? "Type your 6-digit code above and press Enter",
+                Title = canSubmit ? "Submit 2FA code" : "Two-Factor Authentication Required",
+                Subtitle = _errorMessage ?? (canSubmit
+                    ? "Press Enter to submit"
+                    : "Type your 6-8 digit code above and press Enter"),
                 Icon = new IconInfo("\uE8D7"),
             };
             if (_errorMessage != null)
@@ -359,10 +356,17 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         if (_deviceVerificationRequired && _pendingEmail != null && _pendingPassword != null)
         {
             PlaceholderText = "Enter device verification code...";
-            var hint = new ListItem(new NoOpCommand())
+            var code = _currentSearchText.Trim();
+            var canSubmit = code.Length >= 6 && code.Length <= 8 && long.TryParse(code, out _);
+            ICommand command = canSubmit
+                ? new AnonymousCommand(() => OnDeviceVerificationSubmitted(code)) { Name = "Submit", Result = CommandResult.KeepOpen() }
+                : new NoOpCommand();
+            var hint = new ListItem(command)
             {
-                Title = "New Device Verification Required",
-                Subtitle = _errorMessage ?? "Enter the OTP code sent to your login email",
+                Title = canSubmit ? "Submit verification code" : "New Device Verification Required",
+                Subtitle = _errorMessage ?? (canSubmit
+                    ? "Press Enter to submit"
+                    : "Enter the OTP code sent to your login email"),
                 Icon = new IconInfo("\uE8D7"),
             };
             if (_errorMessage != null)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -35,8 +35,6 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private Timer? _syncTimer;
     private ListItem? _syncItem;
     private readonly Timer _iconRefreshTimer;
-    private int _repromptFailures;
-    private DateTime _repromptCooldownUntil;
     private StatusMessage? _lastBiometricStatus;
     private volatile bool _biometricClickFailed;
     private volatile bool _autoBiometricTriggered;
@@ -54,7 +52,6 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         AccessTracker.ItemAccessed += OnItemAccessed;
         FaviconService.IconCached += OnIconCached;
         RepromptPage.GraceStarted += OnRepromptGraceStarted;
-        RepromptPage.VerificationRequested += OnVerificationRequested;
         _iconRefreshTimer = new Timer(OnIconRefreshTick, null, Timeout.Infinite, Timeout.Infinite);
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
         var v = Windows.ApplicationModel.Package.Current.Id.Version;
@@ -586,7 +583,6 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         AccessTracker.ItemAccessed -= OnItemAccessed;
         FaviconService.IconCached -= OnIconCached;
         RepromptPage.GraceStarted -= OnRepromptGraceStarted;
-        RepromptPage.VerificationRequested -= OnVerificationRequested;
     }
 
     private void OnIconCached() => _iconRefreshTimer.Change(500, Timeout.Infinite);
@@ -663,57 +659,6 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 _currentItems = BuildListItems(Search(_currentSearchText));
             RaiseItemsChanged();
         }
-    }
-
-    private void OnVerificationRequested(VerificationRequest request)
-    {
-        if (DateTime.UtcNow < _repromptCooldownUntil)
-        {
-            var remaining = (int)(_repromptCooldownUntil - DateTime.UtcNow).TotalSeconds + 1;
-            var status = new StatusMessage { Message = $"Too many failed attempts. Try again in {remaining}s.", State = MessageState.Error };
-            ExtensionHost.ShowStatus(status, StatusContext.Page);
-            _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(status); } catch { } }, TaskScheduler.Default);
-            return;
-        }
-
-        _handlingAction = true;
-        IsLoading = true;
-        ShowLoadingStatus("Verifying master password...", "bw unlock");
-
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                var verified = await request.Service.VerifyMasterPasswordAsync(request.Password);
-                if (verified)
-                {
-                    _repromptFailures = 0;
-                    RepromptPage.RecordVerification();
-                    request.InnerAction();
-                    var status = new StatusMessage { Message = $"Copied {request.ActionLabel} to clipboard", State = MessageState.Success };
-                    ExtensionHost.ShowStatus(status, StatusContext.Page);
-                    _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(status); } catch { } }, TaskScheduler.Default);
-                }
-                else
-                {
-                    _repromptFailures++;
-                    if (_repromptFailures >= 5)
-                        _repromptCooldownUntil = DateTime.UtcNow.AddSeconds(30);
-                    var status = new StatusMessage { Message = "Incorrect master password", State = MessageState.Error };
-                    ExtensionHost.ShowStatus(status, StatusContext.Page);
-                    _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(status); } catch { } }, TaskScheduler.Default);
-                }
-
-                lock (_itemsLock)
-                    _currentItems = BuildListItems(Search(_currentSearchText));
-                RaiseItemsChanged();
-            }
-            finally
-            {
-                _handlingAction = false;
-                IsLoading = false;
-            }
-        });
     }
 
     private void OnLockRequested()

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -52,6 +52,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         AccessTracker.ItemAccessed += OnItemAccessed;
         FaviconService.IconCached += OnIconCached;
         RepromptPage.GraceStarted += OnRepromptGraceStarted;
+        RepromptPage.BiometricRequested += OnRepromptBiometricRequested;
         _iconRefreshTimer = new Timer(OnIconRefreshTick, null, Timeout.Infinite, Timeout.Infinite);
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
         var v = Windows.ApplicationModel.Package.Current.Id.Version;
@@ -594,6 +595,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         AccessTracker.ItemAccessed -= OnItemAccessed;
         FaviconService.IconCached -= OnIconCached;
         RepromptPage.GraceStarted -= OnRepromptGraceStarted;
+        RepromptPage.BiometricRequested -= OnRepromptBiometricRequested;
     }
 
     private void OnIconCached() => _iconRefreshTimer.Change(500, Timeout.Infinite);
@@ -670,6 +672,73 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 _currentItems = BuildListItems(Search(_currentSearchText));
             RaiseItemsChanged();
         }
+    }
+
+    // Biometric reprompt is handled here (not in RepromptForm) so the WinHello
+    // prompt can come to the foreground. With the form returned via GoBack
+    // first, the items list is showing -- the same UI state where the unlock
+    // biometric path already prompts visibly.
+    private void OnRepromptBiometricRequested(BiometricVerificationRequest request)
+    {
+        DebugLogService.Log("Reprompt", $"Biometric verification requested for item {request.ItemId}");
+
+        _ = Task.Run(async () =>
+        {
+            var connectingStatus = new StatusMessage { Message = "Connecting to Bitwarden Desktop...", State = MessageState.Info };
+            ExtensionHost.ShowStatus(connectingStatus, StatusContext.Page);
+
+            (bool success, string? error) result;
+            try
+            {
+                result = await request.Service.VerifyWithBiometricsAsync(
+                    onStatus: msg => connectingStatus.Message = msg);
+            }
+            catch (Exception ex)
+            {
+                DebugLogService.Log("Reprompt", $"Biometric verify exception: {ex.GetType().Name}: {ex.Message}");
+                result = (false, ex.Message);
+            }
+            finally
+            {
+                try { ExtensionHost.HideStatus(connectingStatus); } catch { }
+            }
+
+            if (!result.success)
+            {
+                RepromptPage.RecordFailure();
+                var cooldown = RepromptPage.GetCooldownSecondsRemaining();
+                var msg = cooldown > 0
+                    ? $"Too many failed attempts. Try again in {cooldown}s."
+                    : result.error ?? "Biometric verification failed";
+                var failStatus = new StatusMessage { Message = msg, State = MessageState.Error };
+                ExtensionHost.ShowStatus(failStatus, StatusContext.Page);
+                _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(failStatus); } catch { } }, TaskScheduler.Default);
+                return;
+            }
+
+            RepromptPage.RecordVerification(request.ItemId);
+            try { request.InnerAction(); }
+            catch (Exception ex)
+            {
+                DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
+                var errStatus = new StatusMessage { Message = "Action failed after verification.", State = MessageState.Error };
+                ExtensionHost.ShowStatus(errStatus, StatusContext.Page);
+                _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(errStatus); } catch { } }, TaskScheduler.Default);
+                return;
+            }
+
+            var successStatus = new StatusMessage { Message = $"Copied {request.ActionLabel} to clipboard", State = MessageState.Success };
+            ExtensionHost.ShowStatus(successStatus, StatusContext.Page);
+            _ = Task.Delay(3000).ContinueWith(_ => { try { ExtensionHost.HideStatus(successStatus); } catch { } }, TaskScheduler.Default);
+
+            // Refresh items so any per-item grace tag updates immediately.
+            if (_service.LastStatus == VaultStatus.Unlocked && _service.IsCacheLoaded)
+            {
+                lock (_itemsLock)
+                    _currentItems = BuildListItems(Search(_currentSearchText));
+                RaiseItemsChanged();
+            }
+        });
     }
 
     private void OnLockRequested()

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -19,7 +19,7 @@ internal sealed partial class RepromptPage : ContentPage
   // grace for that specific item, not for the vault as a whole.
   private static readonly ConcurrentDictionary<string, long> _verifiedItems = new();
   private static int _failureCount;
-  private static DateTime _cooldownUntil;
+  private static long _cooldownUntilTicks;
   private const int MaxFailuresBeforeCooldown = 5;
   private const int CooldownSeconds = 30;
 
@@ -40,20 +40,22 @@ internal sealed partial class RepromptPage : ContentPage
   {
     if (string.IsNullOrEmpty(itemId)) return;
     _verifiedItems[itemId] = Stopwatch.GetTimestamp();
-    _failureCount = 0;
+    Interlocked.Exchange(ref _failureCount, 0);
     GraceStarted?.Invoke();
   }
 
   internal static void ClearGracePeriod()
   {
     _verifiedItems.Clear();
-    _failureCount = 0;
-    _cooldownUntil = default;
+    Interlocked.Exchange(ref _failureCount, 0);
+    Interlocked.Exchange(ref _cooldownUntilTicks, 0);
   }
 
   internal static int GetCooldownSecondsRemaining()
   {
-    var remaining = (_cooldownUntil - DateTime.UtcNow).TotalSeconds;
+    var ticks = Interlocked.Read(ref _cooldownUntilTicks);
+    if (ticks == 0) return 0;
+    var remaining = (new DateTime(ticks, DateTimeKind.Utc) - DateTime.UtcNow).TotalSeconds;
     return remaining > 0 ? (int)Math.Ceiling(remaining) : 0;
   }
 
@@ -61,7 +63,7 @@ internal sealed partial class RepromptPage : ContentPage
   {
     var failures = Interlocked.Increment(ref _failureCount);
     if (failures >= MaxFailuresBeforeCooldown)
-      _cooldownUntil = DateTime.UtcNow.AddSeconds(CooldownSeconds);
+      Interlocked.Exchange(ref _cooldownUntilTicks, DateTime.UtcNow.AddSeconds(CooldownSeconds).Ticks);
   }
 
   private readonly RepromptForm _form;
@@ -70,7 +72,7 @@ internal sealed partial class RepromptPage : ContentPage
   {
     Name = "Verify Password";
     Title = "Master Password Required";
-    Icon = new IconInfo("");
+    Icon = new IconInfo("");
     _form = new RepromptForm(service, itemId, innerAction, actionLabel);
   }
 

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -70,20 +70,29 @@ internal sealed partial class RepromptPage : ContentPage
   {
     Name = "Verify Password";
     Title = "Master Password Required";
-    Icon = new IconInfo("");
+    Icon = new IconInfo("");
     _form = new RepromptForm(service, itemId, innerAction, actionLabel);
   }
 
-  public override IContent[] GetContent() => [_form];
+  public override IContent[] GetContent()
+  {
+    _form.OnPageShown();
+    return [_form];
+  }
 }
 
 internal sealed partial class RepromptForm : FormContent
 {
+  private enum AuthState { Initial, Authenticating, Verified, Failed }
+
   private readonly BitwardenCliService _service;
   private readonly string _itemId;
   private readonly Action _innerAction;
   private readonly string _actionLabel;
+  private AuthState _state = AuthState.Initial;
   private string? _errorText;
+  private string? _statusText;
+  private int _autoTriggered;
 
   public RepromptForm(BitwardenCliService service, string itemId, Action innerAction, string actionLabel)
   {
@@ -91,14 +100,54 @@ internal sealed partial class RepromptForm : FormContent
     _itemId = itemId;
     _innerAction = innerAction;
     _actionLabel = actionLabel;
-    TemplateJson = BuildTemplate(null);
+    TemplateJson = BuildTemplate();
   }
 
-  private void SetError(string? text)
+  internal void OnPageShown()
   {
-    if (_errorText == text) return;
-    _errorText = text;
-    TemplateJson = BuildTemplate(text);
+    if (Interlocked.CompareExchange(ref _autoTriggered, 1, 0) != 0) return;
+    if (!ShouldAutoTriggerBiometric()) return;
+
+    _state = AuthState.Authenticating;
+    _statusText = "Connecting to Bitwarden Desktop...";
+    TemplateJson = BuildTemplate();
+    _ = Task.Run(RunAutoBiometricAsync);
+  }
+
+  private bool ShouldAutoTriggerBiometric()
+  {
+    var settings = _service.Settings;
+    if (settings?.UseDesktopIntegration.Value != true) return false;
+    if (settings?.AutoBiometricUnlock.Value != true) return false;
+    if (RepromptPage.GetCooldownSecondsRemaining() > 0) return false;
+    return true;
+  }
+
+  private async Task RunAutoBiometricAsync()
+  {
+    var (success, error) = await _service.VerifyWithBiometricsAsync(
+      onStatus: msg =>
+      {
+        _statusText = msg;
+        TemplateJson = BuildTemplate();
+      });
+
+    _statusText = null;
+    if (success)
+    {
+      _state = AuthState.Verified;
+      _errorText = null;
+    }
+    else
+    {
+      RepromptPage.RecordFailure();
+      _state = AuthState.Failed;
+      var cooldown = RepromptPage.GetCooldownSecondsRemaining();
+      _errorText = cooldown > 0
+        ? $"Too many failed attempts. Try again in {cooldown}s."
+        : error ?? "Biometric verification failed";
+    }
+    TemplateJson = BuildTemplate();
   }
 
   private static string EscapeJsonString(string value)
@@ -126,8 +175,94 @@ internal sealed partial class RepromptForm : FormContent
     return sb.ToString();
   }
 
-  private static string BuildTemplate(string? errorText) =>
-    """
+  private string BuildTemplate() => _state switch
+  {
+    AuthState.Authenticating => BuildAuthenticatingTemplate(_statusText),
+    AuthState.Verified => BuildVerifiedTemplate(),
+    _ => BuildStandardTemplate(_errorText),
+  };
+
+  private static string BuildAuthenticatingTemplate(string? statusText) =>
+    $$"""
+    {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.6",
+        "body": [
+            {
+                "type": "TextBlock",
+                "size": "medium",
+                "weight": "bolder",
+                "text": "Waiting for Windows Hello...",
+                "horizontalAlignment": "center",
+                "wrap": true,
+                "style": "heading"
+            },
+            {
+                "type": "TextBlock",
+                "text": "{{EscapeJsonString(statusText ?? "Authenticating with Bitwarden Desktop app")}}",
+                "wrap": true,
+                "isSubtle": true,
+                "size": "small",
+                "horizontalAlignment": "center"
+            }
+        ]
+    }
+    """;
+
+  private string BuildVerifiedTemplate() =>
+    $$"""
+    {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.6",
+        "body": [
+            {
+                "type": "TextBlock",
+                "size": "medium",
+                "weight": "bolder",
+                "text": "Verified with Windows Hello",
+                "horizontalAlignment": "center",
+                "wrap": true,
+                "style": "heading",
+                "color": "Good"
+            },
+            {
+                "type": "TextBlock",
+                "text": "Press Enter to {{EscapeJsonString(string.Equals(_actionLabel, "open", StringComparison.OrdinalIgnoreCase) ? "open this item" : $"copy {_actionLabel.ToLowerInvariant()}")}}.",
+                "wrap": true,
+                "isSubtle": true,
+                "size": "small",
+                "horizontalAlignment": "center"
+            },
+            {
+                "type": "ActionSet",
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Continue",
+                        "style": "positive",
+                        "data": { "action": "continue" }
+                    }
+                ]
+            }
+        ]
+    }
+    """;
+
+  private string BuildStandardTemplate(string? errorText)
+  {
+    var biometricEnabled = _service.Settings?.UseDesktopIntegration.Value == true;
+    var biometricAction = biometricEnabled ? """
+                    ,
+                    {
+                        "type": "Action.Submit",
+                        "title": "Use Windows Hello",
+                        "data": { "action": "biometric" }
+                    }
+""" : "";
+
+    return """
     {
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
         "type": "AdaptiveCard",
@@ -154,8 +289,6 @@ internal sealed partial class RepromptForm : FormContent
                 "label": "Master Password",
                 "style": "Password",
                 "id": "MasterPassword",
-                "isRequired": true,
-                "errorMessage": "Master password is required",
                 "placeholder": "Enter your master password"
             },
             {
@@ -163,11 +296,13 @@ internal sealed partial class RepromptForm : FormContent
                 "actions": [
                     {
                         "type": "Action.Submit",
-                        "title": "Verify & Continue"
+                        "title": "Verify & Continue",
+                        "data": { "action": "password" }
                     }
+""" + biometricAction + """
                 ]
             }
-    """ + (errorText != null ? $$"""
+""" + (errorText != null ? $$"""
             ,{
                 "type": "TextBlock",
                 "text": "{{EscapeJsonString(errorText)}}",
@@ -175,12 +310,100 @@ internal sealed partial class RepromptForm : FormContent
                 "wrap": true,
                 "size": "small"
             }
-    """ : "") + """
+""" : "") + """
         ]
     }
     """;
+  }
 
   public override ICommandResult SubmitForm(string inputs, string data)
+  {
+    var actionData = JsonNode.Parse(data)?.AsObject();
+    var action = actionData?["action"]?.GetValue<string>() ?? "password";
+
+    var cooldown = RepromptPage.GetCooldownSecondsRemaining();
+    if (cooldown > 0)
+    {
+      _state = AuthState.Failed;
+      _errorText = $"Too many failed attempts. Try again in {cooldown}s.";
+      TemplateJson = BuildTemplate();
+      return CommandResult.KeepOpen();
+    }
+
+    return action switch
+    {
+      "biometric" => HandleBiometric(),
+      "continue" => HandleContinueAfterAuth(),
+      _ => HandlePassword(inputs),
+    };
+  }
+
+  private CommandResult HandleBiometric()
+  {
+    var status = new StatusMessage { Message = "Connecting to Bitwarden Desktop...", State = MessageState.Info };
+    ExtensionHost.ShowStatus(status, StatusContext.Page);
+
+    bool success;
+    string? error;
+    try
+    {
+#pragma warning disable VSTHRD002
+      var result = Task.Run(() => _service.VerifyWithBiometricsAsync(
+        onStatus: msg => status.Message = msg)).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+      success = result.Success;
+      error = result.Error;
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Biometric exception: {ex.GetType().Name}: {ex.Message}");
+      success = false;
+      error = ex.Message;
+    }
+    finally
+    {
+      try { ExtensionHost.HideStatus(status); } catch { }
+    }
+
+    if (!success)
+    {
+      RepromptPage.RecordFailure();
+      var nextCooldown = RepromptPage.GetCooldownSecondsRemaining();
+      _state = AuthState.Failed;
+      _errorText = nextCooldown > 0
+        ? $"Too many failed attempts. Try again in {nextCooldown}s."
+        : error ?? "Biometric verification failed";
+      TemplateJson = BuildTemplate();
+      return CommandResult.KeepOpen();
+    }
+
+    return RunInnerAction();
+  }
+
+  private CommandResult HandleContinueAfterAuth()
+  {
+    if (_state != AuthState.Verified)
+      return CommandResult.KeepOpen();
+    return RunInnerAction();
+  }
+
+  private CommandResult RunInnerAction()
+  {
+    RepromptPage.RecordVerification(_itemId);
+    try { _innerAction(); }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
+      _state = AuthState.Failed;
+      _errorText = "Action failed after verification.";
+      TemplateJson = BuildTemplate();
+      return CommandResult.KeepOpen();
+    }
+
+    return CommandResult.ShowToast($"Copied {_actionLabel} to clipboard");
+  }
+
+  private CommandResult HandlePassword(string inputs)
   {
     var formInput = JsonNode.Parse(inputs)?.AsObject();
     var password = formInput?["MasterPassword"]?.GetValue<string>();
@@ -188,24 +411,12 @@ internal sealed partial class RepromptForm : FormContent
     if (string.IsNullOrEmpty(password))
       return CommandResult.KeepOpen();
 
-    var cooldown = RepromptPage.GetCooldownSecondsRemaining();
-    if (cooldown > 0)
-    {
-      SetError($"Too many failed attempts. Try again in {cooldown}s.");
-      return CommandResult.KeepOpen();
-    }
-
-    // Show a status while the synchronous CLI verify blocks SubmitForm so
-    // the user has feedback that the click registered.
     var verifyingStatus = new StatusMessage { Message = "Verifying master password...", State = MessageState.Info };
     ExtensionHost.ShowStatus(verifyingStatus, StatusContext.Page);
 
     bool verified;
     try
     {
-      // Run on the thread pool to keep GetResult() deadlock-safe regardless
-      // of the SDK caller's sync context. The CLI call is short and the user
-      // expects a brief pause after submitting their master password.
 #pragma warning disable VSTHRD002
       verified = Task.Run(() => _service.VerifyMasterPasswordAsync(password)).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
@@ -213,7 +424,9 @@ internal sealed partial class RepromptForm : FormContent
     catch (Exception ex)
     {
       DebugLogService.Log("Reprompt", $"Verify exception: {ex.GetType().Name}: {ex.Message}");
-      SetError("Verification failed. Please try again.");
+      _state = AuthState.Failed;
+      _errorText = "Verification failed. Please try again.";
+      TemplateJson = BuildTemplate();
       return CommandResult.KeepOpen();
     }
     finally
@@ -225,21 +438,14 @@ internal sealed partial class RepromptForm : FormContent
     {
       RepromptPage.RecordFailure();
       var nextCooldown = RepromptPage.GetCooldownSecondsRemaining();
-      SetError(nextCooldown > 0
+      _state = AuthState.Failed;
+      _errorText = nextCooldown > 0
         ? $"Too many failed attempts. Try again in {nextCooldown}s."
-        : "Incorrect master password. Please try again.");
+        : "Incorrect master password. Please try again.";
+      TemplateJson = BuildTemplate();
       return CommandResult.KeepOpen();
     }
 
-    RepromptPage.RecordVerification(_itemId);
-    try { _innerAction(); }
-    catch (Exception ex)
-    {
-      DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
-      SetError("Action failed after verification.");
-      return CommandResult.KeepOpen();
-    }
-
-    return CommandResult.ShowToast($"Copied {_actionLabel} to clipboard");
+    return RunInnerAction();
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -223,6 +223,11 @@ internal sealed partial class RepromptForm : FormContent
       return CommandResult.KeepOpen();
     }
 
+    // Show a status while the synchronous CLI verify blocks SubmitForm so
+    // the user has feedback that the click registered.
+    var verifyingStatus = new StatusMessage { Message = "Verifying master password...", State = MessageState.Info };
+    ExtensionHost.ShowStatus(verifyingStatus, StatusContext.Page);
+
     bool verified;
     try
     {
@@ -238,6 +243,10 @@ internal sealed partial class RepromptForm : FormContent
       DebugLogService.Log("Reprompt", $"Verify exception: {ex.GetType().Name}: {ex.Message}");
       SetError("Verification failed. Please try again.");
       return CommandResult.KeepOpen();
+    }
+    finally
+    {
+      try { ExtensionHost.HideStatus(verifyingStatus); } catch { }
     }
 
     if (!verified)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -10,11 +10,13 @@ using HoobiBitwardenCommandPaletteExtension.Services;
 
 namespace HoobiBitwardenCommandPaletteExtension.Pages;
 
+internal record BiometricVerificationRequest(string ItemId, BitwardenCliService Service, Action InnerAction, string ActionLabel);
+
 internal sealed partial class RepromptPage : ContentPage
 {
   internal static int GracePeriodSeconds { get; set; } = 60;
 
-  // Per-item grace timestamps (Stopwatch ticks). In-memory only — verification
+  // Per-item grace timestamps (Stopwatch ticks). In-memory only: verification
   // never persists across process restarts, and a verified item only grants
   // grace for that specific item, not for the vault as a whole.
   private static readonly ConcurrentDictionary<string, long> _verifiedItems = new();
@@ -24,6 +26,7 @@ internal sealed partial class RepromptPage : ContentPage
   private const int CooldownSeconds = 30;
 
   internal static event Action? GraceStarted;
+  internal static event Action<BiometricVerificationRequest>? BiometricRequested;
 
   internal static bool IsWithinGracePeriod(string itemId)
   {
@@ -66,35 +69,29 @@ internal sealed partial class RepromptPage : ContentPage
       Interlocked.Exchange(ref _cooldownUntilTicks, DateTime.UtcNow.AddSeconds(CooldownSeconds).Ticks);
   }
 
+  internal static void RaiseBiometricRequested(BiometricVerificationRequest request) =>
+    BiometricRequested?.Invoke(request);
+
   private readonly RepromptForm _form;
 
   public RepromptPage(BitwardenCliService service, string itemId, Action innerAction, string actionLabel)
   {
     Name = "Verify Password";
     Title = "Master Password Required";
-    Icon = new IconInfo("");
+    Icon = new IconInfo("");
     _form = new RepromptForm(service, itemId, innerAction, actionLabel);
   }
 
-  public override IContent[] GetContent()
-  {
-    _form.OnPageShown();
-    return [_form];
-  }
+  public override IContent[] GetContent() => [_form];
 }
 
 internal sealed partial class RepromptForm : FormContent
 {
-  private enum AuthState { Initial, Authenticating, Verified, Failed }
-
   private readonly BitwardenCliService _service;
   private readonly string _itemId;
   private readonly Action _innerAction;
   private readonly string _actionLabel;
-  private AuthState _state = AuthState.Initial;
   private string? _errorText;
-  private string? _statusText;
-  private int _autoTriggered;
 
   public RepromptForm(BitwardenCliService service, string itemId, Action innerAction, string actionLabel)
   {
@@ -102,53 +99,6 @@ internal sealed partial class RepromptForm : FormContent
     _itemId = itemId;
     _innerAction = innerAction;
     _actionLabel = actionLabel;
-    TemplateJson = BuildTemplate();
-  }
-
-  internal void OnPageShown()
-  {
-    if (Interlocked.CompareExchange(ref _autoTriggered, 1, 0) != 0) return;
-    if (!ShouldAutoTriggerBiometric()) return;
-
-    _state = AuthState.Authenticating;
-    _statusText = "Connecting to Bitwarden Desktop...";
-    TemplateJson = BuildTemplate();
-    _ = Task.Run(RunAutoBiometricAsync);
-  }
-
-  private bool ShouldAutoTriggerBiometric()
-  {
-    var settings = _service.Settings;
-    if (settings?.UseDesktopIntegration.Value != true) return false;
-    if (settings?.AutoBiometricUnlock.Value != true) return false;
-    if (RepromptPage.GetCooldownSecondsRemaining() > 0) return false;
-    return true;
-  }
-
-  private async Task RunAutoBiometricAsync()
-  {
-    var (success, error) = await _service.VerifyWithBiometricsAsync(
-      onStatus: msg =>
-      {
-        _statusText = msg;
-        TemplateJson = BuildTemplate();
-      });
-
-    _statusText = null;
-    if (success)
-    {
-      _state = AuthState.Verified;
-      _errorText = null;
-    }
-    else
-    {
-      RepromptPage.RecordFailure();
-      _state = AuthState.Failed;
-      var cooldown = RepromptPage.GetCooldownSecondsRemaining();
-      _errorText = cooldown > 0
-        ? $"Too many failed attempts. Try again in {cooldown}s."
-        : error ?? "Biometric verification failed";
-    }
     TemplateJson = BuildTemplate();
   }
 
@@ -177,82 +127,7 @@ internal sealed partial class RepromptForm : FormContent
     return sb.ToString();
   }
 
-  private string BuildTemplate() => _state switch
-  {
-    AuthState.Authenticating => BuildAuthenticatingTemplate(_statusText),
-    AuthState.Verified => BuildVerifiedTemplate(),
-    _ => BuildStandardTemplate(_errorText),
-  };
-
-  private static string BuildAuthenticatingTemplate(string? statusText) =>
-    $$"""
-    {
-        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-        "type": "AdaptiveCard",
-        "version": "1.6",
-        "body": [
-            {
-                "type": "TextBlock",
-                "size": "medium",
-                "weight": "bolder",
-                "text": "Waiting for Windows Hello...",
-                "horizontalAlignment": "center",
-                "wrap": true,
-                "style": "heading"
-            },
-            {
-                "type": "TextBlock",
-                "text": "{{EscapeJsonString(statusText ?? "Authenticating with Bitwarden Desktop app")}}",
-                "wrap": true,
-                "isSubtle": true,
-                "size": "small",
-                "horizontalAlignment": "center"
-            }
-        ]
-    }
-    """;
-
-  private string BuildVerifiedTemplate() =>
-    $$"""
-    {
-        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-        "type": "AdaptiveCard",
-        "version": "1.6",
-        "body": [
-            {
-                "type": "TextBlock",
-                "size": "medium",
-                "weight": "bolder",
-                "text": "Verified with Windows Hello",
-                "horizontalAlignment": "center",
-                "wrap": true,
-                "style": "heading",
-                "color": "Good"
-            },
-            {
-                "type": "TextBlock",
-                "text": "Press Enter to {{EscapeJsonString(string.Equals(_actionLabel, "open", StringComparison.OrdinalIgnoreCase) ? "open this item" : $"copy {_actionLabel.ToLowerInvariant()}")}}.",
-                "wrap": true,
-                "isSubtle": true,
-                "size": "small",
-                "horizontalAlignment": "center"
-            },
-            {
-                "type": "ActionSet",
-                "actions": [
-                    {
-                        "type": "Action.Submit",
-                        "title": "Continue",
-                        "style": "positive",
-                        "data": { "action": "continue" }
-                    }
-                ]
-            }
-        ]
-    }
-    """;
-
-  private string BuildStandardTemplate(string? errorText)
+  private string BuildTemplate()
   {
     var biometricEnabled = _service.Settings?.UseDesktopIntegration.Value == true;
     var biometricAction = biometricEnabled ? """
@@ -304,10 +179,10 @@ internal sealed partial class RepromptForm : FormContent
 """ + biometricAction + """
                 ]
             }
-""" + (errorText != null ? $$"""
+""" + (_errorText != null ? $$"""
             ,{
                 "type": "TextBlock",
-                "text": "{{EscapeJsonString(errorText)}}",
+                "text": "{{EscapeJsonString(_errorText)}}",
                 "color": "Attention",
                 "wrap": true,
                 "size": "small"
@@ -326,7 +201,6 @@ internal sealed partial class RepromptForm : FormContent
     var cooldown = RepromptPage.GetCooldownSecondsRemaining();
     if (cooldown > 0)
     {
-      _state = AuthState.Failed;
       _errorText = $"Too many failed attempts. Try again in {cooldown}s.";
       TemplateJson = BuildTemplate();
       return CommandResult.KeepOpen();
@@ -335,74 +209,20 @@ internal sealed partial class RepromptForm : FormContent
     return action switch
     {
       "biometric" => HandleBiometric(),
-      "continue" => HandleContinueAfterAuth(),
       _ => HandlePassword(inputs),
     };
   }
 
+  // Biometric verify is handled by the parent page so the WinHello prompt
+  // can come to the foreground. Doing it inline on the form leaves the
+  // adaptive-card UI mounted, and the WinHello prompt z-orders behind it
+  // (the prompt only becomes visible after the palette closes, by which
+  // time it has already been treated as cancelled).
   private CommandResult HandleBiometric()
   {
-    var status = new StatusMessage { Message = "Connecting to Bitwarden Desktop...", State = MessageState.Info };
-    ExtensionHost.ShowStatus(status, StatusContext.Page);
-
-    bool success;
-    string? error;
-    try
-    {
-#pragma warning disable VSTHRD002
-      var result = Task.Run(() => _service.VerifyWithBiometricsAsync(
-        onStatus: msg => status.Message = msg)).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002
-      success = result.Success;
-      error = result.Error;
-    }
-    catch (Exception ex)
-    {
-      DebugLogService.Log("Reprompt", $"Biometric exception: {ex.GetType().Name}: {ex.Message}");
-      success = false;
-      error = ex.Message;
-    }
-    finally
-    {
-      try { ExtensionHost.HideStatus(status); } catch { }
-    }
-
-    if (!success)
-    {
-      RepromptPage.RecordFailure();
-      var nextCooldown = RepromptPage.GetCooldownSecondsRemaining();
-      _state = AuthState.Failed;
-      _errorText = nextCooldown > 0
-        ? $"Too many failed attempts. Try again in {nextCooldown}s."
-        : error ?? "Biometric verification failed";
-      TemplateJson = BuildTemplate();
-      return CommandResult.KeepOpen();
-    }
-
-    return RunInnerAction();
-  }
-
-  private CommandResult HandleContinueAfterAuth()
-  {
-    if (_state != AuthState.Verified)
-      return CommandResult.KeepOpen();
-    return RunInnerAction();
-  }
-
-  private CommandResult RunInnerAction()
-  {
-    RepromptPage.RecordVerification(_itemId);
-    try { _innerAction(); }
-    catch (Exception ex)
-    {
-      DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
-      _state = AuthState.Failed;
-      _errorText = "Action failed after verification.";
-      TemplateJson = BuildTemplate();
-      return CommandResult.KeepOpen();
-    }
-
-    return CommandResult.ShowToast($"Copied {_actionLabel} to clipboard");
+    RepromptPage.RaiseBiometricRequested(
+      new BiometricVerificationRequest(_itemId, _service, _innerAction, _actionLabel));
+    return CommandResult.GoBack();
   }
 
   private CommandResult HandlePassword(string inputs)
@@ -426,7 +246,6 @@ internal sealed partial class RepromptForm : FormContent
     catch (Exception ex)
     {
       DebugLogService.Log("Reprompt", $"Verify exception: {ex.GetType().Name}: {ex.Message}");
-      _state = AuthState.Failed;
       _errorText = "Verification failed. Please try again.";
       TemplateJson = BuildTemplate();
       return CommandResult.KeepOpen();
@@ -440,7 +259,6 @@ internal sealed partial class RepromptForm : FormContent
     {
       RepromptPage.RecordFailure();
       var nextCooldown = RepromptPage.GetCooldownSecondsRemaining();
-      _state = AuthState.Failed;
       _errorText = nextCooldown > 0
         ? $"Too many failed attempts. Try again in {nextCooldown}s."
         : "Incorrect master password. Please try again.";
@@ -448,6 +266,16 @@ internal sealed partial class RepromptForm : FormContent
       return CommandResult.KeepOpen();
     }
 
-    return RunInnerAction();
+    RepromptPage.RecordVerification(_itemId);
+    try { _innerAction(); }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
+      _errorText = "Action failed after verification.";
+      TemplateJson = BuildTemplate();
+      return CommandResult.KeepOpen();
+    }
+
+    return CommandResult.ShowToast($"Copied {_actionLabel} to clipboard");
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -107,9 +107,20 @@ internal sealed partial class RepromptPage : ContentPage
   public override IContent[] GetContent() => [_form];
 }
 
-internal sealed partial class RepromptForm(BitwardenCliService service, Action innerAction, string actionLabel) : FormContent
+internal sealed partial class RepromptForm : FormContent
 {
+  private readonly BitwardenCliService _service;
+  private readonly Action _innerAction;
+  private readonly string _actionLabel;
   private string? _errorText;
+
+  public RepromptForm(BitwardenCliService service, Action innerAction, string actionLabel)
+  {
+    _service = service;
+    _innerAction = innerAction;
+    _actionLabel = actionLabel;
+    TemplateJson = BuildTemplate(null);
+  }
 
   private void SetError(string? text)
   {
@@ -219,7 +230,7 @@ internal sealed partial class RepromptForm(BitwardenCliService service, Action i
       // of the SDK caller's sync context. The CLI call is short and the user
       // expects a brief pause after submitting their master password.
 #pragma warning disable VSTHRD002
-      verified = Task.Run(() => service.VerifyMasterPasswordAsync(password)).GetAwaiter().GetResult();
+      verified = Task.Run(() => _service.VerifyMasterPasswordAsync(password)).GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002
     }
     catch (Exception ex)
@@ -240,7 +251,7 @@ internal sealed partial class RepromptForm(BitwardenCliService service, Action i
     }
 
     RepromptPage.RecordVerification();
-    try { innerAction(); }
+    try { _innerAction(); }
     catch (Exception ex)
     {
       DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
@@ -248,6 +259,6 @@ internal sealed partial class RepromptForm(BitwardenCliService service, Action i
       return CommandResult.KeepOpen();
     }
 
-    return CommandResult.ShowToast($"Copied {actionLabel} to clipboard");
+    return CommandResult.ShowToast($"Copied {_actionLabel} to clipboard");
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -2,14 +2,13 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using System.Text.Json.Nodes;
 using HoobiBitwardenCommandPaletteExtension.Services;
 
 namespace HoobiBitwardenCommandPaletteExtension.Pages;
-
-internal record VerificationRequest(string Password, BitwardenCliService Service, Action InnerAction, string ActionLabel);
 
 internal sealed partial class RepromptPage : ContentPage
 {
@@ -20,9 +19,12 @@ internal sealed partial class RepromptPage : ContentPage
     "HoobiBitwardenCommandPalette", "grace.json");
 
   private static long _lastVerifiedTs;
+  private static int _failureCount;
+  private static DateTime _cooldownUntil;
+  private const int MaxFailuresBeforeCooldown = 5;
+  private const int CooldownSeconds = 30;
 
   internal static event Action? GraceStarted;
-  internal static event Action<VerificationRequest>? VerificationRequested;
 
   internal static bool IsWithinGracePeriod()
   {
@@ -56,6 +58,7 @@ internal sealed partial class RepromptPage : ContentPage
   internal static void RecordVerification()
   {
     Interlocked.Exchange(ref _lastVerifiedTs, Stopwatch.GetTimestamp());
+    _failureCount = 0;
     PersistGrace();
     GraceStarted?.Invoke();
   }
@@ -63,7 +66,22 @@ internal sealed partial class RepromptPage : ContentPage
   internal static void ClearGracePeriod()
   {
     Interlocked.Exchange(ref _lastVerifiedTs, 0);
+    _failureCount = 0;
+    _cooldownUntil = default;
     try { File.Delete(GraceFile); } catch { }
+  }
+
+  internal static int GetCooldownSecondsRemaining()
+  {
+    var remaining = (_cooldownUntil - DateTime.UtcNow).TotalSeconds;
+    return remaining > 0 ? (int)Math.Ceiling(remaining) : 0;
+  }
+
+  internal static void RecordFailure()
+  {
+    var failures = Interlocked.Increment(ref _failureCount);
+    if (failures >= MaxFailuresBeforeCooldown)
+      _cooldownUntil = DateTime.UtcNow.AddSeconds(CooldownSeconds);
   }
 
   private static void PersistGrace()
@@ -76,16 +94,13 @@ internal sealed partial class RepromptPage : ContentPage
     catch { }
   }
 
-  internal static void RaiseVerificationRequested(VerificationRequest request) =>
-    VerificationRequested?.Invoke(request);
-
   private readonly RepromptForm _form;
 
   public RepromptPage(BitwardenCliService service, Action innerAction, string actionLabel)
   {
     Name = "Verify Password";
     Title = "Master Password Required";
-    Icon = new IconInfo("\uE72E");
+    Icon = new IconInfo("");
     _form = new RepromptForm(service, innerAction, actionLabel);
   }
 
@@ -94,24 +109,41 @@ internal sealed partial class RepromptPage : ContentPage
 
 internal sealed partial class RepromptForm(BitwardenCliService service, Action innerAction, string actionLabel) : FormContent
 {
-  private bool _showError;
+  private string? _errorText;
 
-  internal void ShowError()
+  private void SetError(string? text)
   {
-    _showError = true;
-    TemplateJson = BuildTemplate(showError: true);
+    if (_errorText == text) return;
+    _errorText = text;
+    TemplateJson = BuildTemplate(text);
   }
 
-  internal void ResetError()
+  private static string EscapeJsonString(string value)
   {
-    if (_showError)
+    var sb = new System.Text.StringBuilder(value.Length);
+    foreach (var c in value)
     {
-      _showError = false;
-      TemplateJson = BuildTemplate(showError: false);
+      switch (c)
+      {
+        case '"': sb.Append("\\\""); break;
+        case '\\': sb.Append("\\\\"); break;
+        case '\b': sb.Append("\\b"); break;
+        case '\f': sb.Append("\\f"); break;
+        case '\n': sb.Append("\\n"); break;
+        case '\r': sb.Append("\\r"); break;
+        case '\t': sb.Append("\\t"); break;
+        default:
+          if (c < 0x20)
+            sb.Append(System.Globalization.CultureInfo.InvariantCulture, $"\\u{(int)c:x4}");
+          else
+            sb.Append(c);
+          break;
+      }
     }
+    return sb.ToString();
   }
 
-  private static string BuildTemplate(bool showError) =>
+  private static string BuildTemplate(string? errorText) =>
     """
     {
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
@@ -152,10 +184,10 @@ internal sealed partial class RepromptForm(BitwardenCliService service, Action i
                     }
                 ]
             }
-    """ + (showError ? """
+    """ + (errorText != null ? $$"""
             ,{
                 "type": "TextBlock",
-                "text": "Incorrect master password. Please try again.",
+                "text": "{{EscapeJsonString(errorText)}}",
                 "color": "Attention",
                 "wrap": true,
                 "size": "small"
@@ -173,9 +205,49 @@ internal sealed partial class RepromptForm(BitwardenCliService service, Action i
     if (string.IsNullOrEmpty(password))
       return CommandResult.KeepOpen();
 
-    RepromptPage.RaiseVerificationRequested(
-      new VerificationRequest(password, service, innerAction, actionLabel));
+    var cooldown = RepromptPage.GetCooldownSecondsRemaining();
+    if (cooldown > 0)
+    {
+      SetError($"Too many failed attempts. Try again in {cooldown}s.");
+      return CommandResult.KeepOpen();
+    }
 
-    return CommandResult.GoBack();
+    bool verified;
+    try
+    {
+      // Run on the thread pool to keep GetResult() deadlock-safe regardless
+      // of the SDK caller's sync context. The CLI call is short and the user
+      // expects a brief pause after submitting their master password.
+#pragma warning disable VSTHRD002
+      verified = Task.Run(() => service.VerifyMasterPasswordAsync(password)).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Verify exception: {ex.GetType().Name}: {ex.Message}");
+      SetError("Verification failed. Please try again.");
+      return CommandResult.KeepOpen();
+    }
+
+    if (!verified)
+    {
+      RepromptPage.RecordFailure();
+      var nextCooldown = RepromptPage.GetCooldownSecondsRemaining();
+      SetError(nextCooldown > 0
+        ? $"Too many failed attempts. Try again in {nextCooldown}s."
+        : "Incorrect master password. Please try again.");
+      return CommandResult.KeepOpen();
+    }
+
+    RepromptPage.RecordVerification();
+    try { innerAction(); }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Inner action exception: {ex.GetType().Name}: {ex.Message}");
+      SetError("Action failed after verification.");
+      return CommandResult.KeepOpen();
+    }
+
+    return CommandResult.ShowToast($"Copied {actionLabel} to clipboard");
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
@@ -14,11 +14,10 @@ internal sealed partial class RepromptPage : ContentPage
 {
   internal static int GracePeriodSeconds { get; set; } = 60;
 
-  private static readonly string GraceFile = Path.Combine(
-    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-    "HoobiBitwardenCommandPalette", "grace.json");
-
-  private static long _lastVerifiedTs;
+  // Per-item grace timestamps (Stopwatch ticks). In-memory only — verification
+  // never persists across process restarts, and a verified item only grants
+  // grace for that specific item, not for the vault as a whole.
+  private static readonly ConcurrentDictionary<string, long> _verifiedItems = new();
   private static int _failureCount;
   private static DateTime _cooldownUntil;
   private const int MaxFailuresBeforeCooldown = 5;
@@ -26,49 +25,30 @@ internal sealed partial class RepromptPage : ContentPage
 
   internal static event Action? GraceStarted;
 
-  internal static bool IsWithinGracePeriod()
+  internal static bool IsWithinGracePeriod(string itemId)
   {
-    if (GracePeriodSeconds <= 0) return false;
-
-    var ts = Interlocked.Read(ref _lastVerifiedTs);
-    if (ts != 0 && Stopwatch.GetElapsedTime(ts).TotalSeconds < GracePeriodSeconds)
+    if (GracePeriodSeconds <= 0 || string.IsNullOrEmpty(itemId)) return false;
+    if (!_verifiedItems.TryGetValue(itemId, out var ts)) return false;
+    if (Stopwatch.GetElapsedTime(ts).TotalSeconds < GracePeriodSeconds)
       return true;
 
-    try
-    {
-      if (!File.Exists(GraceFile)) return false;
-      var json = File.ReadAllText(GraceFile);
-      if (JsonNode.Parse(json)?["verified"]?.GetValue<long>() is long utcTicks)
-      {
-        var elapsed = DateTime.UtcNow - new DateTime(utcTicks, DateTimeKind.Utc);
-        if (elapsed.TotalSeconds < GracePeriodSeconds)
-        {
-          Interlocked.CompareExchange(ref _lastVerifiedTs,
-            Stopwatch.GetTimestamp() - (long)(elapsed.TotalSeconds * Stopwatch.Frequency),
-            0);
-          return true;
-        }
-      }
-    }
-    catch { }
-
+    _verifiedItems.TryRemove(itemId, out _);
     return false;
   }
 
-  internal static void RecordVerification()
+  internal static void RecordVerification(string itemId)
   {
-    Interlocked.Exchange(ref _lastVerifiedTs, Stopwatch.GetTimestamp());
+    if (string.IsNullOrEmpty(itemId)) return;
+    _verifiedItems[itemId] = Stopwatch.GetTimestamp();
     _failureCount = 0;
-    PersistGrace();
     GraceStarted?.Invoke();
   }
 
   internal static void ClearGracePeriod()
   {
-    Interlocked.Exchange(ref _lastVerifiedTs, 0);
+    _verifiedItems.Clear();
     _failureCount = 0;
     _cooldownUntil = default;
-    try { File.Delete(GraceFile); } catch { }
   }
 
   internal static int GetCooldownSecondsRemaining()
@@ -84,24 +64,14 @@ internal sealed partial class RepromptPage : ContentPage
       _cooldownUntil = DateTime.UtcNow.AddSeconds(CooldownSeconds);
   }
 
-  private static void PersistGrace()
-  {
-    try
-    {
-      Directory.CreateDirectory(Path.GetDirectoryName(GraceFile)!);
-      File.WriteAllText(GraceFile, $"{{\"verified\":{DateTime.UtcNow.Ticks}}}");
-    }
-    catch { }
-  }
-
   private readonly RepromptForm _form;
 
-  public RepromptPage(BitwardenCliService service, Action innerAction, string actionLabel)
+  public RepromptPage(BitwardenCliService service, string itemId, Action innerAction, string actionLabel)
   {
     Name = "Verify Password";
     Title = "Master Password Required";
     Icon = new IconInfo("");
-    _form = new RepromptForm(service, innerAction, actionLabel);
+    _form = new RepromptForm(service, itemId, innerAction, actionLabel);
   }
 
   public override IContent[] GetContent() => [_form];
@@ -110,13 +80,15 @@ internal sealed partial class RepromptPage : ContentPage
 internal sealed partial class RepromptForm : FormContent
 {
   private readonly BitwardenCliService _service;
+  private readonly string _itemId;
   private readonly Action _innerAction;
   private readonly string _actionLabel;
   private string? _errorText;
 
-  public RepromptForm(BitwardenCliService service, Action innerAction, string actionLabel)
+  public RepromptForm(BitwardenCliService service, string itemId, Action innerAction, string actionLabel)
   {
     _service = service;
+    _itemId = itemId;
     _innerAction = innerAction;
     _actionLabel = actionLabel;
     TemplateJson = BuildTemplate(null);
@@ -259,7 +231,7 @@ internal sealed partial class RepromptForm : FormContent
       return CommandResult.KeepOpen();
     }
 
-    RepromptPage.RecordVerification();
+    RepromptPage.RecordVerification(_itemId);
     try { _innerAction(); }
     catch (Exception ex)
     {

--- a/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
@@ -119,7 +119,9 @@ internal sealed partial class UnlockForm : FormContent
     if (action == "biometric")
     {
       _onBiometricUnlock?.Invoke();
-      return CommandResult.KeepOpen();
+      // Same behavior as the password path: the unlock runs asynchronously
+      // on the parent page (status + items refresh), so the form is done.
+      return CommandResult.GoBack();
     }
 
     var password = formInput?["MasterPassword"]?.GetValue<string>();

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -436,6 +436,35 @@ internal sealed class BitwardenCliService
     }
   }
 
+  // Reload the saved session credential and verify it still works, transitioning
+  // the vault to Unlocked + refreshing the cache. Used by the page to bypass the
+  // biometric/password prompt after a soft auto-lock when RememberSession is on
+  // — the stored credential is still valid, so re-prompting the user provides
+  // no security benefit and is just friction.
+  public async Task<bool> TryRestoreSessionAsync()
+  {
+    if (_settings?.RememberSession.Value != true) return false;
+    if (_lastStatus == VaultStatus.Unlocked && _sessionKey != null) return true;
+
+    var stored = SessionStore.Load();
+    if (string.IsNullOrEmpty(stored)) return false;
+
+    DebugLogService.Log("Restore", "Attempting silent session restore from Credential Manager");
+    _sessionKey = stored;
+    if (!await VerifySessionAsync())
+    {
+      DebugLogService.Log("Restore", "Stored session verification failed; clearing credential");
+      SessionStore.Clear();
+      return false;
+    }
+
+    SetStatus(VaultStatus.Unlocked);
+    StatusChanged?.Invoke();
+    try { await RefreshCacheAsync(); }
+    catch (Exception ex) { DebugLogService.Log("Restore", $"RefreshCacheAsync after restore failed: {ex.GetType().Name}: {ex.Message}"); }
+    return true;
+  }
+
   public async Task<(bool Success, string? Error)> UnlockWithBiometricsAsync(Action<string>? onStatus = null)
   {
     DebugLogService.Log("Unlock", "UnlockWithBiometricsAsync started");

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -188,6 +188,20 @@ internal sealed class BitwardenCliService
       _lastRememberSession = false;
       _ = LockAsync();
     }
+    else if (!_lastRememberSession && current)
+    {
+      _lastRememberSession = true;
+      // Toggling RememberSession on while the vault is unlocked means the user
+      // wants the active session to survive the next process restart. Persist
+      // the in-memory key now — UnlockWithBiometricsAsync / UnlockAsync only
+      // saves when RememberSession was already on at unlock time.
+      var key = _sessionKey;
+      if (!string.IsNullOrEmpty(key))
+      {
+        SessionStore.Save(key);
+        DebugLogService.Log("Session", "RememberSession enabled with active session; persisted credential");
+      }
+    }
     else
     {
       _lastRememberSession = current;

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -315,7 +315,8 @@ internal sealed class BitwardenCliService
           _sessionKey = stored;
           if (await VerifySessionAsync())
           {
-            Pages.RepromptPage.RecordVerification();
+            // Vault unlock no longer grants protected-item grace; that has to
+            // be earned per-item via RepromptForm.
             return SetStatus(VaultStatus.Unlocked);
           }
           DebugLogService.Log("Status", "Stored session verification failed, clearing");
@@ -1212,7 +1213,6 @@ internal sealed class BitwardenCliService
           if (IsCacheLoaded)
           {
             SetStatus(VaultStatus.Unlocked);
-            Pages.RepromptPage.RecordVerification();
             _ = Task.Run(async () =>
             {
               try { await RunCliAsync("sync", CliTimeoutMs, "Syncing complete."); DebugLogService.Log("Sync", "Background sync completed"); }

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -475,8 +475,11 @@ internal sealed class BitwardenCliService
     _sessionKey = stored;
     if (!await VerifySessionAsync())
     {
-      DebugLogService.Log("Restore", "Stored session verification failed; clearing credential");
-      SessionStore.Clear();
+      // Same policy as GetVaultStatusCoreAsync: a single bw sync failure can
+      // be transient (network blip, slow CLI startup), so don't burn the
+      // saved credential here. HandleInvalidSession clears it on real CLI
+      // errors that confirm the session is gone.
+      DebugLogService.Log("Restore", "Stored session verification failed (preserving credential for retry)");
       return false;
     }
 

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -319,8 +319,14 @@ internal sealed class BitwardenCliService
             // be earned per-item via RepromptForm.
             return SetStatus(VaultStatus.Unlocked);
           }
-          DebugLogService.Log("Status", "Stored session verification failed, clearing");
-          SessionStore.Clear();
+          // Don't clear the credential here — a single sync failure can be a
+          // transient network blip or slow CLI startup right after a deploy,
+          // and clearing means the user is forced to biometric/password on
+          // the next launch even though the credential is still valid. Leave
+          // it in place; HandleInvalidSession (called from real CLI errors
+          // with stderr that confirms the session is gone) will clear it
+          // when the credential is genuinely bad.
+          DebugLogService.Log("Status", "Stored session verification failed (preserving credential for retry)");
         }
         else
         {
@@ -437,10 +443,12 @@ internal sealed class BitwardenCliService
   }
 
   // Reload the saved session credential and verify it still works, transitioning
-  // the vault to Unlocked + refreshing the cache. Used by the page to bypass the
-  // biometric/password prompt after a soft auto-lock when RememberSession is on
-  // — the stored credential is still valid, so re-prompting the user provides
-  // no security benefit and is just friction.
+  // the vault to Unlocked + refreshing the cache. Used by the page as a backup
+  // path: after a transient warmup failure, after HandleInvalidSession fires on
+  // a real CLI error that turns out to have been transient, etc. Auto-lock and
+  // user-initiated locks now hard-lock (clearing the credential), so this only
+  // succeeds in genuine "the credential is fine, we just lost the in-memory
+  // session" scenarios — exactly the cases where re-prompting would be friction.
   public async Task<bool> TryRestoreSessionAsync()
   {
     if (_settings?.RememberSession.Value != true) return false;
@@ -861,10 +869,12 @@ internal sealed class BitwardenCliService
 
   public async Task LockAsync(bool userInitiated = false)
   {
-    var rememberSession = _settings?.RememberSession.Value == true && !userInitiated;
-    DebugLogService.Log("Lock", rememberSession
-      ? "LockAsync called (soft lock, rememberSession=True)"
-      : userInitiated ? "LockAsync called (user-initiated, clearing credential)" : "LockAsync called");
+    // Both auto-lock and user-initiated lock perform a hard lock: clear the
+    // in-memory session, the saved credential, and run `bw lock` against the
+    // CLI. RememberSession only controls whether the credential is restored
+    // on process restart (warmup); once a lock event has fired the user has
+    // explicitly asked us to forget the unlocked state.
+    DebugLogService.Log("Lock", userInitiated ? "LockAsync (user-initiated)" : "LockAsync (auto-lock)");
     _sessionKey = null;
     SetStatus(VaultStatus.Locked);
     lock (_cacheLock)
@@ -873,16 +883,12 @@ internal sealed class BitwardenCliService
       _cacheLoaded = false;
     }
     FaviconService.ClearMemCache();
-    if (!rememberSession)
-      SessionStore.Clear();
+    SessionStore.Clear();
     Pages.RepromptPage.ClearGracePeriod();
     StatusChanged?.Invoke();
 
-    if (!rememberSession)
-    {
-      try { await RunCliAsync("lock", CliTimeoutMs, "Your vault is locked."); }
-      catch (Exception ex) { DebugLogService.Log("Auth", $"bw lock failed (non-critical): {ex.GetType().Name}: {ex.Message}"); }
-    }
+    try { await RunCliAsync("lock", CliTimeoutMs, "Your vault is locked."); }
+    catch (Exception ex) { DebugLogService.Log("Auth", $"bw lock failed (non-critical): {ex.GetType().Name}: {ex.Message}"); }
   }
 
   public async Task<string?> SetServerUrlAsync(ServerConfig config)

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -555,6 +555,25 @@ internal sealed class BitwardenCliService
     }
   }
 
+  internal BitwardenSettingsManager? Settings => _settings;
+
+  public async Task<(bool Success, string? Error)> VerifyWithBiometricsAsync(Action<string>? onStatus = null)
+  {
+    DebugLogService.Log("Reprompt", "Verifying via biometrics");
+    try
+    {
+      var success = await DesktopIpcService.TryBiometricVerifyAsync(DataDirectory, onStatus);
+      return success
+        ? (true, null)
+        : (false, "Biometric verification was cancelled or denied");
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Reprompt", $"Biometric verify exception: {ex.GetType().Name}: {ex.Message}");
+      return (false, ex.Message);
+    }
+  }
+
   public async Task<bool> VerifyMasterPasswordAsync(string password)
   {
     DebugLogService.Log("Reprompt", "Verifying master password for re-prompt");

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
@@ -188,25 +188,36 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         TotpTagStyle.Value = "static";
         BackgroundRefresh.Value = "5";
         RepromptGracePeriod.Value = "60";
+        Settings.Add(new SectionHeaderSetting("_section_auth", "Authentication", separator: false));
         Settings.Add(RememberSession);
         Settings.Add(UseDesktopIntegration);
         Settings.Add(AutoBiometricUnlock);
-        Settings.Add(ShowWebsiteIcons);
         Settings.Add(AutoLockTimeout);
+        Settings.Add(RepromptGracePeriod);
+
+        Settings.Add(new SectionHeaderSetting("_section_display", "Vault Display"));
+        Settings.Add(ShowWebsiteIcons);
         Settings.Add(ShowWatchtowerTags);
-        Settings.Add(ContextAwareness);
-        Settings.Add(ShowContextTag);
         Settings.Add(ShowProtectedTag);
         Settings.Add(ShowPasskeyTag);
         Settings.Add(TotpTagStyle);
-        Settings.Add(ContextItemLimit);
         Settings.Add(BackgroundRefresh);
+
+        Settings.Add(new SectionHeaderSetting("_section_context", "Context Awareness"));
+        Settings.Add(ContextAwareness);
+        Settings.Add(ShowContextTag);
+        Settings.Add(ContextItemLimit);
+
+        Settings.Add(new SectionHeaderSetting("_section_clipboard", "Clipboard"));
         Settings.Add(AutoClearClipboard);
         Settings.Add(ClipboardClearDelay);
+
+        Settings.Add(new SectionHeaderSetting("_section_cli", "Bitwarden CLI"));
         Settings.Add(CliDirectoryOverride);
         Settings.Add(UsePortableDataDirectory);
         Settings.Add(CliDataDirectoryOverride);
-        Settings.Add(RepromptGracePeriod);
+
+        Settings.Add(new SectionHeaderSetting("_section_advanced", "Advanced"));
         Settings.Add(DebugLogging);
         CaptureDefaults();
         Settings.SettingsChanged += OnSettingsChanged;
@@ -272,22 +283,22 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         yield return (RememberSession.Key, (object?)RememberSession.Value);
         yield return (UseDesktopIntegration.Key, (object?)UseDesktopIntegration.Value);
         yield return (AutoBiometricUnlock.Key, (object?)AutoBiometricUnlock.Value);
+        yield return (AutoLockTimeout.Key, AutoLockTimeout.Value);
+        yield return (RepromptGracePeriod.Key, RepromptGracePeriod.Value);
         yield return (ShowWebsiteIcons.Key, ShowWebsiteIcons.Value);
         yield return (ShowWatchtowerTags.Key, ShowWatchtowerTags.Value);
-        yield return (ContextAwareness.Key, ContextAwareness.Value);
-        yield return (ShowContextTag.Key, ShowContextTag.Value);
         yield return (ShowProtectedTag.Key, (object?)ShowProtectedTag.Value);
         yield return (ShowPasskeyTag.Key, ShowPasskeyTag.Value);
         yield return (TotpTagStyle.Key, TotpTagStyle.Value);
-        yield return (AutoLockTimeout.Key, AutoLockTimeout.Value);
+        yield return (BackgroundRefresh.Key, BackgroundRefresh.Value);
+        yield return (ContextAwareness.Key, ContextAwareness.Value);
+        yield return (ShowContextTag.Key, ShowContextTag.Value);
+        yield return (ContextItemLimit.Key, ContextItemLimit.Value);
         yield return (AutoClearClipboard.Key, AutoClearClipboard.Value);
         yield return (ClipboardClearDelay.Key, ClipboardClearDelay.Value);
-        yield return (ContextItemLimit.Key, ContextItemLimit.Value);
-        yield return (BackgroundRefresh.Key, BackgroundRefresh.Value);
         yield return (CliDirectoryOverride.Key, CliDirectoryOverride.Value);
         yield return (UsePortableDataDirectory.Key, (object?)UsePortableDataDirectory.Value);
         yield return (CliDataDirectoryOverride.Key, CliDataDirectoryOverride.Value);
-        yield return (RepromptGracePeriod.Key, RepromptGracePeriod.Value);
         yield return (DebugLogging.Key, (object?)DebugLogging.Value);
     }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Services/DesktopIpcService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/DesktopIpcService.cs
@@ -93,6 +93,46 @@ internal static partial class DesktopIpcService
     }
   }
 
+  public static async Task<bool> TryBiometricVerifyAsync(string? dataDirectory, Action<string>? onStatus = null)
+  {
+    var userId = GetActiveUserId(dataDirectory);
+    if (userId == null)
+    {
+      DebugLogService.Log("Biometric", "No active user ID found in CLI data.json");
+      return false;
+    }
+
+    DebugLogService.Log("Biometric", $"Attempting biometric verify for user {userId[..Math.Min(8, userId.Length)]}...");
+
+    using var client = new IpcClient();
+    onStatus?.Invoke("Connecting to Bitwarden Desktop app...");
+    await client.ConnectAsync(userId, onStatus);
+
+    onStatus?.Invoke("Checking biometrics availability...");
+    var status = await client.GetBiometricsStatusForUserAsync(userId);
+    if (status != BiometricsStatus.Available)
+    {
+      DebugLogService.Log("Biometric", $"Biometrics not available: {status}");
+      var reason = status switch
+      {
+        BiometricsStatus.UnlockNeeded => "Bitwarden Desktop app is locked - unlock it first",
+        BiometricsStatus.HardwareUnavailable => "Windows Hello hardware not available",
+        BiometricsStatus.AutoSetupNeeded or BiometricsStatus.ManualSetupNeeded => "Biometrics not set up in Bitwarden Desktop app",
+        BiometricsStatus.NotEnabledLocally or BiometricsStatus.NotEnabledInConnectedDesktopApp => "Enable 'Unlock with biometrics' in Bitwarden Desktop settings",
+        BiometricsStatus.DesktopDisconnected => "Bitwarden Desktop app disconnected",
+        _ => $"Biometrics unavailable (status: {status})",
+      };
+      throw new InvalidOperationException(reason);
+    }
+
+    DebugLogService.Log("Biometric", "Requesting Windows Hello prompt for verify...");
+    onStatus?.Invoke("Waiting for Windows Hello...");
+    var userKeyB64 = await client.UnlockWithBiometricsForUserAsync(userId);
+    var success = !string.IsNullOrEmpty(userKeyB64);
+    DebugLogService.Log("Biometric", success ? "Biometric verify successful" : "Biometric verify denied or failed");
+    return success;
+  }
+
   public static async Task<bool> IsBiometricsAvailableAsync(string? dataDirectory)
   {
     var userId = GetActiveUserId(dataDirectory);

--- a/HoobiBitwardenCommandPaletteExtension/Services/SectionHeaderSetting.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/SectionHeaderSetting.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace HoobiBitwardenCommandPaletteExtension.Services;
+
+internal sealed class SectionHeaderSetting : Setting<bool>
+{
+    private readonly bool _separator;
+
+    public SectionHeaderSetting(string key, string label, bool separator = true)
+        : base(key, false)
+    {
+        Label = label;
+        _separator = separator;
+    }
+
+    public override Dictionary<string, object> ToDictionary() => new()
+    {
+        { "type", "TextBlock" },
+        { "text", Label },
+        { "weight", "Bolder" },
+        { "size", "Medium" },
+        { "separator", _separator },
+        { "spacing", _separator ? "Large" : "Small" },
+        { "wrap", true },
+    };
+
+    public override void Update(JsonObject payload)
+    {
+    }
+
+    public override string ToState() => $"\"{Key}\": \"\"";
+}

--- a/HoobiBitwardenCommandPaletteExtension/Services/SessionStore.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/SessionStore.cs
@@ -6,7 +6,17 @@ namespace HoobiBitwardenCommandPaletteExtension.Services;
 
 internal static class SessionStore
 {
+  // MSIX scopes Win32 CredWrite/CredRead per package family name. Dev and
+  // Release builds have different identities (.Debug suffix vs not) so they
+  // can't see each other's credentials — and the saved credential from one
+  // looks like a stale orphan to the other. Use a different target name per
+  // build configuration so each owns its own slot, with no surprising
+  // cross-build behavior when switching between them.
+#if DEBUG
+  private const string TargetName = "BitwardenCommandPaletteExtension.Debug/default_sessionToken";
+#else
   private const string TargetName = "BitwardenCommandPaletteExtension/default_sessionToken";
+#endif
   private const int CredTypeGeneric = 1;
   private const int CredPersistLocalMachine = 2;
 


### PR DESCRIPTION
## Summary

Two unrelated fixes that landed on top of the post-1.7.1 bundle (#146).

## Changes

### `perf(search)`: 100ms debounce on keystroke-driven rebuilds
- `UpdateSearchText` was rebuilding the full item list on every keystroke: filter+sort the cache, then build 5-15 `ICommand` objects per result via `BuildContextItems` plus tags.
- With the `TrackedInvokable` decorator subscribing to `PropChanged` per construction (#143), fast typing allocates thousands of commands per second on larger vaults and the search field feels laggy.
- Each keystroke now (re)arms a `Timer`; the rebuild and `RaiseItemsChanged` only run after the user pauses. Standard pattern for palette UIs (Spotlight, VS Code pickers).

### `fix(ci)`: work around immutable-release repo semantics
- **Pre-release**: `softprops/action-gh-release` publishes the release before uploading assets, which fails on immutable-release repos with *Cannot upload asset to an immutable release*. Switched to `draft: true` + `gh release edit --draft=false --prerelease` so assets land while the release is mutable.
- **Release trust-signal**: the step looked up the release ID via `/releases/tags/{tag}`, which returns 404 for the release-please draft (no tag yet). Use `gh release view`/`edit` instead, both of which resolve drafts by name.

## Testing

- [x] Manual: typing in the palette feels snappy on a ~200-item vault
- [x] Existing tests pass (\`dotnet test -p:Platform=x64\`)
- [ ] CI fix verified end-to-end: needs a release-please PR + a publish to confirm both paths