### PR TITLE
fix: search debounce and release pipeline immutable-release fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -701,12 +701,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # release-please leaves the release as a draft; the REST endpoint
+          # /releases/tags/{tag} returns 404 for drafts (the tag isn't created
+          # until publish). `gh release view` lists drafts and matches by name,
+          # so we use it to read the current body and `gh release edit` to
+          # rewrite it. The draft flip-to-published happens in the next step.
           TAG="${{ needs.release-please.outputs.tag_name }}"
-          ID=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.id')
-          BODY=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG" --jq '.body // ""')
+          BODY=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body // ""')
           TRUST=$'\n\n---\n> ✅ WACK certified (x64, ARM64) · \U0001F512 [CodeQL scanned](https://github.com/${{ github.repository }}/actions/workflows/codeql.yml)'
-          jq -n --arg body "${BODY}${TRUST}" '{body: $body}' \
-            | gh api --method PATCH "repos/${{ github.repository }}/releases/$ID" --input -
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes "${BODY}${TRUST}"
 
       - name: Publish draft release
         uses: hoobio/pipeline-tools/pipeline/github/step/publish-github-release@v1.5.0
@@ -782,17 +785,31 @@ jobs:
           name: msi-ARM64
           path: release/msi-ARM64
 
-      - name: Create pre-release
+      # Create as a draft so action-gh-release can attach assets. On repos
+      # with "immutable releases" enabled, publishing a release locks its
+      # asset list, and softprops/action-gh-release publishes before
+      # uploading - so non-draft prereleases fail with "Cannot upload asset
+      # ... to an immutable release". Keeping it as a draft lets the upload
+      # complete; the next step flips it to a published prerelease.
+      - name: Create pre-release (draft)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
           name: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
           prerelease: true
+          draft: true
           make_latest: false
           body_path: /tmp/release_notes.txt
           files: |
             release/**/*.msix
             release/**/*.msi
+
+      - name: Publish pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ steps.version.outputs.version }}-pre.${{ github.run_number }}
+        run: |
+          gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false --prerelease
 
       - name: Prune old pre-releases
         env:

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -35,6 +35,15 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private Timer? _syncTimer;
     private ListItem? _syncItem;
     private readonly Timer _iconRefreshTimer;
+    private readonly Timer _searchDebounceTimer;
+    // Debounce window for the unlocked-vault search rebuild. Each keystroke
+    // resets the timer; the rebuild only runs after the user pauses for this
+    // long. BuildListItems allocates 5-15 commands per result, so doing it
+    // per keystroke (with no debounce) makes typing feel laggy on larger
+    // vaults. 100ms is the sweet spot used by most palette UIs (VS Code,
+    // Spotlight): below the threshold of perceived input delay, but enough
+    // to collapse a typed word into a single rebuild.
+    private const int SearchDebounceMs = 100;
     private StatusMessage? _lastBiometricStatus;
     private volatile bool _biometricClickFailed;
     private volatile bool _autoBiometricTriggered;
@@ -54,6 +63,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         RepromptPage.GraceStarted += OnRepromptGraceStarted;
         RepromptPage.BiometricRequested += OnRepromptBiometricRequested;
         _iconRefreshTimer = new Timer(OnIconRefreshTick, null, Timeout.Infinite, Timeout.Infinite);
+        _searchDebounceTimer = new Timer(OnSearchDebounceTick, null, Timeout.Infinite, Timeout.Infinite);
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.png");
         var v = Windows.ApplicationModel.Package.Current.Id.Version;
         var version = $"{v.Major}.{v.Minor}.{v.Build}";
@@ -184,8 +194,9 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
 
         if (_service.IsCacheLoaded)
         {
-            _currentItems = BuildListItems(Search(newSearch));
-            RaiseItemsChanged();
+            // Debounce: each keystroke just (re)arms the timer. The actual
+            // rebuild + RaiseItemsChanged runs once the user pauses typing.
+            _searchDebounceTimer.Change(SearchDebounceMs, Timeout.Infinite);
             _service.TriggerBackgroundRefreshIfStale();
         }
         else
@@ -196,6 +207,17 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 await _service.RefreshCacheAsync();
             });
         }
+    }
+
+    private void OnSearchDebounceTick(object? _)
+    {
+        // Re-check state at fire time: the vault may have locked, an action
+        // may be in flight, or the cache may have been invalidated since the
+        // keystroke that armed the timer.
+        if (_handlingAction || _service.LastStatus != VaultStatus.Unlocked || !_service.IsCacheLoaded)
+            return;
+        _currentItems = BuildListItems(Search(_currentSearchText));
+        RaiseItemsChanged();
     }
 
     private void OnCacheUpdated()
@@ -586,6 +608,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _totpTimer?.Dispose();
         _syncTimer?.Dispose();
         _iconRefreshTimer.Dispose();
+        _searchDebounceTimer.Dispose();
         _service.CacheUpdated -= OnCacheUpdated;
         _service.StatusChanged -= OnStatusChanged;
         _service.WarmupCompleted -= OnWarmupCompleted;


### PR DESCRIPTION
## Summary

Two unrelated post-1.9.0 fixes.

## Changes

### `perf(search)`: 100ms debounce on keystroke-driven rebuilds
- `UpdateSearchText` was rebuilding the full item list on every keystroke: filter+sort the cache, then build 5-15 `ICommand` objects per result via `BuildContextItems` plus tags.
- With the `TrackedInvokable` decorator subscribing to `PropChanged` per construction (#143), fast typing allocates thousands of commands per second on larger vaults and the search field feels laggy.
- Each keystroke now (re)arms a `Timer`; the rebuild and `RaiseItemsChanged` only run after the user pauses. Standard pattern for palette UIs (Spotlight, VS Code pickers).

### `fix(ci)`: work around immutable-release repo semantics
- **Pre-release**: `softprops/action-gh-release` publishes the release before uploading assets, which fails on immutable-release repos with *Cannot upload asset to an immutable release*. Switched to `draft: true` + `gh release edit --draft=false --prerelease` so assets land while the release is mutable.
- **Release trust-signal**: the step looked up the release ID via `/releases/tags/{tag}`, which returns 404 for the release-please draft (no tag yet). Use `gh release view`/`edit` instead, both of which resolve drafts by name.

## Testing

- [x] Manual: typing in the palette feels snappy on a ~200-item vault
- [x] Existing tests pass (\`dotnet test -p:Platform=x64\`)
- [ ] CI fix verified end-to-end: needs a release-please PR + a publish to confirm both paths