### PR TITLE
fix: 🐛 re-assert session key after silent restore verify to unstick cache

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -483,6 +483,13 @@ internal sealed class BitwardenCliService
       return false;
     }
 
+    // bw sync can take seconds. A concurrent HandleInvalidSession (e.g. an
+    // in-flight warmup `bw list` returning "Vault is locked") may have nulled
+    // _sessionKey while we were verifying. The verify just proved the stored
+    // credential is valid, so re-assert it before SetStatus/RefreshCacheAsync,
+    // otherwise IsUnlocked stays false and the cache refresh silently skips,
+    // leaving the page stuck on "Retrieving items from vault...".
+    _sessionKey = stored;
     SetStatus(VaultStatus.Unlocked);
     StatusChanged?.Invoke();
     try { await RefreshCacheAsync(); }
@@ -1296,8 +1303,14 @@ internal sealed class BitwardenCliService
         }
         catch (InvalidOperationException)
         {
-          DebugLogService.Log("Warmup", "Fast session restore failed (session expired), clearing credential");
-          SessionStore.Clear();
+          // HandleInvalidSession already cleared in-memory state with the
+          // correct RememberSession policy (preserves the stored credential
+          // when RememberSession=True). Don't override that here: a single
+          // "Vault is locked" from the CLI can be transient, and clearing the
+          // credential races with TryRestoreSessionAsync (triggered by the
+          // status change) which has likely already loaded the same credential
+          // and is verifying it in parallel.
+          DebugLogService.Log("Warmup", "Fast session restore failed (session expired), falling back to status check");
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes a race condition where the palette gets stuck on "Retrieving items from vault..." after a transient startup failure.

## Changes

- `TryRestoreSessionAsync`: re-assert `_sessionKey = stored` after `VerifySessionAsync` returns true. Closes the race where a concurrent `HandleInvalidSession` (e.g. an in-flight warmup `bw list` returning "Vault is locked") nulls `_sessionKey` mid-verify, leaving `IsUnlocked=false` so the subsequent `RefreshCacheAsync` silently skips.
- `RunWarmupAsync`: stop calling `SessionStore.Clear()` on the `InvalidOperationException` catch. `HandleInvalidSession` already applies the correct `RememberSession` policy (preserves the stored credential when on). The warmup's clear contradicted that policy and also races with `TryRestoreSessionAsync` (which is triggered by the same status change and loads the same credential in parallel).

## Repro / debug log

A user log captured the race exactly:

```
13.605 [Restore] Attempting silent session restore from Credential Manager
13.605 [Verify] Running bw sync to verify session             ← _sessionKey = stored
13.817 [CLI]    Session invalid detected in bw list items: 'Vault is locked.'
13.817 [Session] HandleInvalidSession: clearing session ...   ← _sessionKey = null (clobbers above)
13.819 [Warmup] Fast session restore failed ..., clearing credential
16.606 [Verify] sync stdout: Syncing complete.
16.618 [Verify] Session verified successfully
16.618 [Page]   RebuildForCurrentStatus: status=Unlocked, cacheLoaded=False
16.618 [Cache]  RefreshCacheAsync skipped: vault not unlocked ← IsUnlocked still false
```

Every subsequent `RefreshCacheAsync` skipped forever, even when the user opened the palette hours later (`LastStatus=Unlocked`, but `_sessionKey=null`).

## Testing

- [x] Existing tests pass (`dotnet test -p:Platform=x64`): 435/436. The one pre-existing failure (`VaultItemHelperTests.RecordVerification_DoesNotPersistAcrossProcesses`) reproduces on `main`, unrelated to this fix.
- [ ] Manual repro is timing-sensitive, no new unit test added.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
- [ ] Coverage threshold (no logic added beyond a single assignment + log message change)