### PR TITLE
perf: 🚀 bound favicon download concurrency and prioritise visible items

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -18,12 +18,12 @@ namespace HoobiBitwardenCommandPaletteExtension.Helpers;
 
 internal static partial class VaultItemHelper
 {
-  internal static IconInfo GetIcon(BitwardenItem item, bool showWebsiteIcons = true) => item.Type switch
+  internal static IconInfo GetIcon(BitwardenItem item, bool showWebsiteIcons = true, int priority = int.MaxValue) => item.Type switch
   {
-    BitwardenItemType.Login => showWebsiteIcons ? GetFaviconIcon(item) : new IconInfo("\uE774"),
+    BitwardenItemType.Login => showWebsiteIcons ? GetFaviconIcon(item, priority) : new IconInfo("\uE774"),
     BitwardenItemType.SecureNote => new IconInfo("\uE70B"),
     BitwardenItemType.Card => showWebsiteIcons && item.CardBrand != null
-      ? GetCardBrandIcon(item.CardBrand)
+      ? GetCardBrandIcon(item.CardBrand, priority)
       : new IconInfo("\uE8C7"),
     BitwardenItemType.Identity => new IconInfo("\uE77B"),
     BitwardenItemType.SshKey => new IconInfo("\uE8D7"),
@@ -418,7 +418,7 @@ internal static partial class VaultItemHelper
     return $"{GetVaultBaseUrl()}/images/{slug}-{theme}.png";
   }
 
-  internal static IconInfo GetCardBrandIcon(string brand)
+  internal static IconInfo GetCardBrandIcon(string brand, int priority = int.MaxValue)
   {
     var isDark = IsDarkTheme();
     var slug = SanitizeBrandSlug(brand);
@@ -426,10 +426,11 @@ internal static partial class VaultItemHelper
     return FaviconService.GetOrQueue(
       $"card-brand:{slug}:{theme}",
       GetCardBrandImageUrl(brand, isDark),
-      new IconInfo("\uE8C7"));
+      new IconInfo("\uE8C7"),
+      priority);
   }
 
-  internal static IconInfo GetFaviconIcon(BitwardenItem item)
+  internal static IconInfo GetFaviconIcon(BitwardenItem item, int priority = int.MaxValue)
   {
     var host = item.FirstHost;
     if (string.IsNullOrEmpty(host))
@@ -448,7 +449,7 @@ internal static partial class VaultItemHelper
       iconBase = serverUrl + "/icons";
     var iconUrl = $"{iconBase}/{host}/icon.png";
 
-    return FaviconService.GetOrQueue(host, iconUrl);
+    return FaviconService.GetOrQueue(host, iconUrl, priority: priority);
   }
 
   internal static OpenUrlCommand BuildOpenInWebVaultCommand(string itemId) =>

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -44,6 +44,16 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     // Spotlight): below the threshold of perceived input delay, but enough
     // to collapse a typed word into a single rebuild.
     private const int SearchDebounceMs = 100;
+    // IconCached can fire many times per second during a cold vault load (each of
+    // ~580 logins resolves to its own callback). A pure trailing-edge debounce
+    // would defer the rebuild until the entire load finishes, hiding progress for
+    // ~10-30s on a slow connection. Instead, coalesce within IconRefreshDebounceMs,
+    // but force a rebuild every IconRefreshMaxWaitMs so the user sees icons appear
+    // incrementally during a long fetch run.
+    private const int IconRefreshDebounceMs = 500;
+    private const int IconRefreshMaxWaitMs = 2000;
+    private DateTime _iconRefreshFirstQueuedAt;
+    private readonly Lock _iconRefreshLock = new();
     private StatusMessage? _lastBiometricStatus;
     private volatile bool _biometricClickFailed;
     private volatile bool _autoBiometricTriggered;
@@ -543,6 +553,10 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             list.Add(new ListItem(new NoOpCommand()) { Title = "No results found" });
         else
         {
+            // Item index is passed to FaviconService as the download priority so the
+            // first items in the visible list fetch their icons before the tail. The
+            // command palette host renders results in this exact order.
+            var iconPriority = 0;
             foreach (var item in items)
             {
                 var allowContextTag = showContextTag;
@@ -555,7 +569,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 // When capContextTags is true, ContextScore was already evaluated above — pass context: null
                 // and showContextTag: allowContextTag to avoid a redundant ContextScore call in BuildTags/BuildBaseTags.
                 var contextForTags = capContextTags ? null : _context;
-                var listItem = BuildListItem(item, showWatchtower, allowContextTag, totpTagStyle, showPasskeyTag, showProtectedTag, showWebsiteIcons, contextForTags);
+                var listItem = BuildListItem(item, showWatchtower, allowContextTag, totpTagStyle, showPasskeyTag, showProtectedTag, showWebsiteIcons, contextForTags, iconPriority++);
                 list.Add(listItem);
                 if (totpTagStyle == "live" && item.HasTotp)
                 {
@@ -586,13 +600,13 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         return list.ToArray();
     }
 
-    private ListItem BuildListItem(BitwardenItem item, bool showWatchtower, bool showContextTag, string totpTagStyle, bool showPasskeyTag, bool showProtectedTag, bool showWebsiteIcons = true, ForegroundContext? context = null)
+    private ListItem BuildListItem(BitwardenItem item, bool showWatchtower, bool showContextTag, string totpTagStyle, bool showPasskeyTag, bool showProtectedTag, bool showWebsiteIcons = true, ForegroundContext? context = null, int iconPriority = int.MaxValue)
     {
         var listItem = new ListItem(VaultItemHelper.GetDefaultCommand(item, _service))
         {
             Title = item.Name,
             Subtitle = item.Subtitle,
-            Icon = VaultItemHelper.GetIcon(item, showWebsiteIcons),
+            Icon = VaultItemHelper.GetIcon(item, showWebsiteIcons, iconPriority),
             MoreCommands = VaultItemHelper.BuildContextItems(item, _service),
         };
 
@@ -621,10 +635,23 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         RepromptPage.BiometricRequested -= OnRepromptBiometricRequested;
     }
 
-    private void OnIconCached() => _iconRefreshTimer.Change(500, Timeout.Infinite);
+    private void OnIconCached()
+    {
+        lock (_iconRefreshLock)
+        {
+            if (_iconRefreshFirstQueuedAt == default)
+                _iconRefreshFirstQueuedAt = DateTime.UtcNow;
+            var elapsedMs = (int)(DateTime.UtcNow - _iconRefreshFirstQueuedAt).TotalMilliseconds;
+            var dueIn = Math.Max(0, Math.Min(IconRefreshDebounceMs, IconRefreshMaxWaitMs - elapsedMs));
+            _iconRefreshTimer.Change(dueIn, Timeout.Infinite);
+        }
+    }
 
     private void OnIconRefreshTick(object? _)
     {
+        lock (_iconRefreshLock)
+            _iconRefreshFirstQueuedAt = default;
+
         if (_handlingAction || _service.LastStatus != VaultStatus.Unlocked || !_service.IsCacheLoaded)
             return;
         _currentItems = BuildListItems(Search(_currentSearchText));

--- a/HoobiBitwardenCommandPaletteExtension/Services/FaviconService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/FaviconService.cs
@@ -22,13 +22,30 @@ internal static partial class FaviconService
     private static readonly TimeSpan PositiveTtl = TimeSpan.FromDays(7);
     private static readonly TimeSpan NegativeTtl = TimeSpan.FromMinutes(5);
 
+    // Bounded concurrency: 8 in-flight downloads saturates a typical home/office
+    // connection without overwhelming the icons host or HttpClient's default per-host
+    // connection limit. Higher values get head-of-line-blocked by the server anyway
+    // and increase the chance of timeouts on a cold-vault load.
+    private const int MaxConcurrentDownloads = 8;
+
     private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
 
     // Cached icon: raster bytes streamed via COM. null = negative cache (host has no icon); missing key = not yet tried
     private static readonly ConcurrentDictionary<string, byte[]?> _memCache = new();
     private static readonly ConcurrentDictionary<string, IconInfo> _iconInfoCache = new();
-    private static readonly HashSet<string> _pending = [];
-    private static readonly Lock _pendingLock = new();
+
+    // Priority queue gated by a worker pool of size MaxConcurrentDownloads.
+    // Lower Priority value = downloaded sooner. Callers pass the item's index in the
+    // visible list so head-of-list icons load before tail. When a host is re-enqueued
+    // with a better priority (e.g. it now appears earlier in a new search result),
+    // the old heap entry stays put as a tombstone and is dropped at dequeue time
+    // because its priority no longer matches the current value in _queuedHosts.
+    private static readonly Lock _queueLock = new();
+    private static readonly PriorityQueue<string, int> _queue = new();
+    private static readonly Dictionary<string, (string IconUrl, int Priority)> _queuedHosts = [];
+    private static readonly HashSet<string> _inFlight = [];
+    private static readonly SemaphoreSlim _signal = new(0);
+    private static int _workersInitialized;
 
     /// <summary>Fired on the thread-pool when any new icon is successfully cached.</summary>
     public static event Action? IconCached;
@@ -41,13 +58,14 @@ internal static partial class FaviconService
     }
 
     /// <summary>
-    /// Returns an <see cref="IconInfo"/> for the given host.
-    /// Uses the disk cache when available; otherwise returns the fallback icon and
-    /// schedules a background download.
+    /// Returns an <see cref="IconInfo"/> for the given host. Uses the disk cache when
+    /// available; otherwise returns the fallback icon and schedules a bounded-concurrency
+    /// background download. <paramref name="priority"/> orders pending downloads
+    /// (lower = sooner). Default <see cref="int.MaxValue"/> sends the host to the tail.
     /// </summary>
-    public static IconInfo GetOrQueue(string host, string iconUrl, IconInfo? fallback = null)
+    public static IconInfo GetOrQueue(string host, string iconUrl, IconInfo? fallback = null, int priority = int.MaxValue)
     {
-        fallback ??= new IconInfo("\uE774");
+        fallback ??= new IconInfo("");
         if (_iconInfoCache.TryGetValue(host, out var cachedIcon))
             return cachedIcon;
         if (_memCache.TryGetValue(host, out var cachedBytes))
@@ -69,14 +87,70 @@ internal static partial class FaviconService
             return fallback;
         }
 
-        bool shouldFetch;
-        lock (_pendingLock)
-            shouldFetch = _pending.Add(host);
-
-        if (shouldFetch)
-            _ = Task.Run(() => DownloadAsync(host, iconUrl));
-
+        Enqueue(host, iconUrl, priority);
         return fallback;
+    }
+
+    private static void Enqueue(string host, string iconUrl, int priority)
+    {
+        bool needsSignal;
+        lock (_queueLock)
+        {
+            if (_inFlight.Contains(host)) return;
+
+            if (_queuedHosts.TryGetValue(host, out var existing) && priority >= existing.Priority)
+                return;
+
+            _queuedHosts[host] = (iconUrl, priority);
+            _queue.Enqueue(host, priority);
+            needsSignal = true;
+        }
+        if (needsSignal)
+        {
+            EnsureWorkersStarted();
+            _signal.Release();
+        }
+    }
+
+    private static void EnsureWorkersStarted()
+    {
+        if (Interlocked.Exchange(ref _workersInitialized, 1) != 0) return;
+        for (var i = 0; i < MaxConcurrentDownloads; i++)
+            _ = Task.Run(WorkerLoopAsync);
+    }
+
+    private static async Task WorkerLoopAsync()
+    {
+        while (true)
+        {
+            await _signal.WaitAsync().ConfigureAwait(false);
+            var job = TryDequeueJob();
+            if (job is null) continue;
+            var (host, iconUrl) = job.Value;
+            try { await DownloadAsync(host, iconUrl).ConfigureAwait(false); }
+            finally
+            {
+                lock (_queueLock) _inFlight.Remove(host);
+            }
+        }
+    }
+
+    private static (string Host, string IconUrl)? TryDequeueJob()
+    {
+        lock (_queueLock)
+        {
+            while (_queue.TryDequeue(out var host, out var priority))
+            {
+                if (_queuedHosts.TryGetValue(host, out var entry) && entry.Priority == priority)
+                {
+                    _queuedHosts.Remove(host);
+                    _inFlight.Add(host);
+                    return (host, entry.IconUrl);
+                }
+                // Stale entry from a priority bump; skip and try the next.
+            }
+            return null;
+        }
     }
 
     private static async Task DownloadAsync(string host, string iconUrl)
@@ -130,11 +204,6 @@ internal static partial class FaviconService
         {
             try { await NegCacheAsync(negPath, $"{iconUrl}\nException: {ex.GetType().Name}: {ex.Message}"); } catch { }
             _memCache[host] = null;
-        }
-        finally
-        {
-            lock (_pendingLock)
-                _pending.Remove(host);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes long icon-loading delays on cold vault load. Previously `FaviconService.GetOrQueue` fired one HTTP request per item with no concurrency cap (up to ~580 simultaneous), and every successful fetch triggered a 500ms-debounced full list rebuild that kept getting deferred until the entire load finished, so the user saw no icons for ~10-30s.

## Changes

- **Bounded concurrency.** `FaviconService` now runs 8 worker tasks fed by a `PriorityQueue<string, int>` instead of unbounded `Task.Run` per call. Caps the OS connection fan-out at the icons host's tolerance.
- **Priority queue.** `GetOrQueue` accepts an `int priority` (lower = sooner). `BuildListItems` passes the item index, so the head of the visible result list fetches before the tail. Re-enqueue with a better priority bumps the host up; the old heap entry becomes a tombstone dropped at dequeue.
- **Coalesced rebuild with max wait.** `OnIconCached` still debounces 500ms, but force-fires the rebuild every 2s during a sustained arrival stream. The user sees icons appear incrementally instead of one big reveal at the end of a cold load.

## Testing

- [x] Existing tests pass (`dotnet test -p:Platform=x64`): 435/436. The one failure (`VaultItemHelperTests.RecordVerification_DoesNotPersistAcrossProcesses`) is the pre-existing failure already flagged on `main` (see #153 checklist), unrelated.
- [ ] Manual testing with PowerToys Command Palette (owner to verify cold-load behaviour)
- [ ] Unit tests added/updated — not added: the changed logic is a static singleton wrapping a static `HttpClient`, and all three changed files (`FaviconService.cs`, `VaultItemHelper.cs`, `Pages/*`) are in [`coverage-exclusions.json`](.github/coverage-exclusions.json), so the threshold doesn't apply. Adding deterministic tests would require non-trivial refactoring for DI/test hooks; happy to do that as a follow-up if you'd like.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build -c Debug -p:Platform=x64`)
- [x] Changed `.cs` files meet the 50% coverage threshold (all three are in `coverage-exclusions.json`)
- [x] Wiki docs updated (no behaviour or settings change visible to users)