### PR TITLE
fix: 🐛 default 2FA method to TOTP plus method picker and prompt polish

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -191,12 +191,23 @@ public class BitwardenCliServiceMockedTests
   }
 
   [Fact]
+  public async Task Login_WithTwoFactorCode_DefaultsToTotpMethod()
+  {
+    // Regression: self-hosted servers were returning email as the default 2FA
+    // method when --method was omitted, causing valid TOTP codes to be rejected.
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "session123\n", stderr: "", exitCode: 0));
+    await svc.LoginAsync("user@test.com", "pass", "123456");
+    Assert.Contains("--method 0", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
   public async Task Login_WithTwoFactorCodeAndMethod_IncludesMethodInArgs()
   {
     var (svc, factory) = CreateService();
     factory.Enqueue(new FakeCliProcess(stdout: "session123\n", stderr: "", exitCode: 0));
-    await svc.LoginAsync("user@test.com", "pass", "123456", 0);
-    Assert.Contains("--method 0", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    await svc.LoginAsync("user@test.com", "pass", "123456", 1);
+    Assert.Contains("--method 1", factory.LastPsi!.Arguments, StringComparison.Ordinal);
   }
 
   [Fact]

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -211,6 +211,18 @@ public class BitwardenCliServiceMockedTests
   }
 
   [Fact]
+  public async Task Login_WithExplicitNullMethod_OmitsMethodFlag()
+  {
+    // Escape hatch: callers can opt out of the TOTP safety net to let the CLI
+    // auto-select the 2FA method (matches the "None" choice in the login form).
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "session123\n", stderr: "", exitCode: 0));
+    await svc.LoginAsync("user@test.com", "pass", "123456", twoFactorMethod: null);
+    Assert.DoesNotContain("--method", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--code", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
   public async Task Login_SanitizesEmail()
   {
     var (svc, factory) = CreateService();

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -223,6 +223,19 @@ public class BitwardenCliServiceMockedTests
   }
 
   [Fact]
+  public async Task Login_MethodWithoutCode_OmitsMethodFlag()
+  {
+    // We deliberately do NOT pass --method on the first login attempt (no code),
+    // because that would make bw call postTwoFactorEmail for Email 2FA, which
+    // vaultwarden rejects with 422 (missing deviceIdentifier).
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "Two-step login is required.\n", exitCode: 1));
+    await svc.LoginAsync("user@test.com", "pass", twoFactorCode: null, twoFactorMethod: 1);
+    Assert.DoesNotContain("--method", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.DoesNotContain("--code", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
   public async Task Login_SanitizesEmail()
   {
     var (svc, factory) = CreateService();

--- a/HoobiBitwardenCommandPaletteExtension.Tests/LoginFormTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/LoginFormTests.cs
@@ -1,0 +1,31 @@
+using HoobiBitwardenCommandPaletteExtension.Pages;
+
+namespace HoobiBitwardenCommandPaletteExtension.Tests;
+
+public class LoginFormTests
+{
+  [Theory]
+  [InlineData("0", 0)]
+  [InlineData("1", 1)]
+  [InlineData("3", 3)]
+  public void ParseTwoFactorMethod_NumericValue_ReturnsInt(string raw, int expected)
+  {
+    Assert.Equal(expected, LoginForm.ParseTwoFactorMethod(raw));
+  }
+
+  [Theory]
+  [InlineData("none")]
+  [InlineData("NONE")]
+  [InlineData("")]
+  [InlineData(null)]
+  public void ParseTwoFactorMethod_NoneOrEmpty_ReturnsNull(string? raw)
+  {
+    Assert.Null(LoginForm.ParseTwoFactorMethod(raw));
+  }
+
+  [Fact]
+  public void ParseTwoFactorMethod_Garbage_FallsBackToTotp()
+  {
+    Assert.Equal(0, LoginForm.ParseTwoFactorMethod("not-a-number"));
+  }
+}

--- a/HoobiBitwardenCommandPaletteExtension.Tests/LoginFormTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/LoginFormTests.cs
@@ -1,9 +1,26 @@
+using System.Text.Json.Nodes;
 using HoobiBitwardenCommandPaletteExtension.Pages;
 
 namespace HoobiBitwardenCommandPaletteExtension.Tests;
 
 public class LoginFormTests
 {
+  [Fact]
+  public void BuildCustomDataDirWarningBlock_EscapesPathAndParsesAsJson()
+  {
+    var block = LoginForm.BuildCustomDataDirWarningBlock(@"C:\Users\test\bw data");
+    Assert.EndsWith(",", block.TrimEnd(), StringComparison.Ordinal);
+
+    var jsonObject = block.TrimEnd().TrimEnd(',');
+    var parsed = JsonNode.Parse(jsonObject)?.AsObject();
+    Assert.NotNull(parsed);
+    Assert.Equal("TextBlock", parsed!["type"]!.GetValue<string>());
+    Assert.Equal("attention", parsed["color"]!.GetValue<string>());
+    Assert.Contains(@"C:\Users\test\bw data", parsed["text"]!.GetValue<string>(), StringComparison.Ordinal);
+    Assert.Contains("BITWARDENCLI_APPDATA_DIR", parsed["text"]!.GetValue<string>(), StringComparison.Ordinal);
+  }
+
+
   [Theory]
   [InlineData("0", 0)]
   [InlineData("1", 1)]

--- a/HoobiBitwardenCommandPaletteExtension.Tests/TwoFactorMethodDescriptorTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/TwoFactorMethodDescriptorTests.cs
@@ -1,0 +1,72 @@
+using HoobiBitwardenCommandPaletteExtension;
+
+namespace HoobiBitwardenCommandPaletteExtension.Tests;
+
+public class TwoFactorMethodDescriptorTests
+{
+  [Fact]
+  public void Describe_Authenticator_NumericCopyAndValidator()
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(0);
+    Assert.Contains("authenticator", d.Placeholder, StringComparison.OrdinalIgnoreCase);
+    Assert.Equal("authenticator code", d.TypedNoun);
+    Assert.True(d.Validator("123456"));
+    Assert.False(d.Validator("abcdef"));
+  }
+
+  [Fact]
+  public void Describe_Email_NumericCopyAndValidator()
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(1);
+    Assert.Contains("email", d.Placeholder, StringComparison.OrdinalIgnoreCase);
+    Assert.Equal("email code", d.TypedNoun);
+    Assert.True(d.Validator("654321"));
+  }
+
+  [Fact]
+  public void Describe_Yubikey_TouchCopyAndAlphanumericValidator()
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(3);
+    Assert.Contains("YubiKey", d.Placeholder, StringComparison.Ordinal);
+    Assert.Equal("YubiKey OTP", d.TypedNoun);
+    // 44-char modhex-style OTP
+    Assert.True(d.Validator("cccccccbcdefghijklnrtuv1234567890abcdefghijk"));
+    // Numeric TOTP code should be rejected for YubiKey
+    Assert.False(d.Validator("123456"));
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData(2)]   // Duo (not in dropdown)
+  [InlineData(99)]  // Unknown
+  public void Describe_UnknownOrNull_FallsBackToGenericNumeric(int? method)
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(method);
+    Assert.Equal("2FA code", d.TypedNoun);
+    Assert.True(d.Validator("123456"));
+    Assert.False(d.Validator("ab"));
+  }
+
+  [Theory]
+  [InlineData("12345")]      // too short
+  [InlineData("123456789")]  // too long
+  [InlineData("12 3456")]    // whitespace
+  [InlineData("-123456")]    // signed
+  [InlineData("12.3456")]    // not integer
+  [InlineData("")]
+  public void NumericValidator_RejectsInvalidShapes(string raw)
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(0);
+    Assert.False(d.Validator(raw));
+  }
+
+  [Theory]
+  [InlineData("short")]                                                       // too short
+  [InlineData("with space inside the otp xxxxxxxxxxxxxxxxxxx")]               // non-alphanumeric
+  [InlineData("")]
+  public void YubikeyValidator_RejectsInvalidShapes(string raw)
+  {
+    var d = HoobiBitwardenCommandPaletteExtensionPage.DescribeTwoFactorMethod(3);
+    Assert.False(d.Validator(raw));
+  }
+}

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -26,6 +26,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private string? _errorMessage;
     private string? _pendingEmail;
     private string? _pendingPassword;
+    private int? _pendingTwoFactorMethod;
     private bool _twoFactorRequired;
     private bool _deviceVerificationRequired;
     private ForegroundContext? _context;
@@ -664,6 +665,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _deviceVerificationRequired = false;
         _pendingEmail = null;
         _pendingPassword = null;
+        _pendingTwoFactorMethod = null;
         _errorMessage = null;
         IsLoading = true;
         ShowLoadingStatus("Checking vault status...", "bw status");
@@ -1038,9 +1040,9 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         });
     }
 
-    private void OnLoginSubmitted(string email, string password)
+    private void OnLoginSubmitted(string email, string password, int? twoFactorMethod)
     {
-        DebugLogService.Log("Action", "Login submitted by user");
+        DebugLogService.Log("Action", $"Login submitted by user (2FA method: {(twoFactorMethod?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "auto")})");
         _handlingAction = true;
         ClearSearchText();
         _errorMessage = null;
@@ -1048,6 +1050,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _deviceVerificationRequired = false;
         _pendingEmail = null;
         _pendingPassword = null;
+        _pendingTwoFactorMethod = null;
         _currentItems = [];
         IsLoading = true;
         RaiseItemsChanged();
@@ -1065,6 +1068,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                         _twoFactorRequired = true;
                         _pendingEmail = email;
                         _pendingPassword = password;
+                        _pendingTwoFactorMethod = twoFactorMethod;
                         _errorMessage = null;
                     }
                     else if (deviceVerificationRequired)
@@ -1114,7 +1118,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             try
             {
                 ShowLoadingStatus("Verifying 2FA code...", "bw login");
-                var (success, error, _, _) = await _service.LoginAsync(email!, password!, twoFactorCode);
+                var (success, error, _, _) = await _service.LoginAsync(email!, password!, twoFactorCode, _pendingTwoFactorMethod);
                 if (!success)
                 {
                     _errorMessage = error?.Contains("Code", StringComparison.OrdinalIgnoreCase) == true
@@ -1128,6 +1132,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 _twoFactorRequired = false;
                 _pendingEmail = null;
                 _pendingPassword = null;
+                _pendingTwoFactorMethod = null;
                 PlaceholderText = "Search your vault... (try is:fav, is:protected, folder:Work, has:totp, has:passkey, url:github)";
                 ShowLoadingStatus("Syncing vault...", "bw sync");
                 await _service.SyncVaultAsync();

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -358,23 +358,22 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     {
         if (_twoFactorRequired && _pendingEmail != null && _pendingPassword != null)
         {
-            PlaceholderText = "Enter your 2FA code...";
+            var (placeholder, typedNoun, emptyHint, validator) = DescribeTwoFactorMethod(_pendingTwoFactorMethod);
+            PlaceholderText = placeholder;
             var code = _currentSearchText.Trim();
-            var canSubmit = code.Length >= 6 && code.Length <= 8 && long.TryParse(code, out _);
+            var canSubmit = validator(code);
             ICommand command = canSubmit
                 ? new AnonymousCommand(() => OnTwoFactorSubmitted(code)) { Name = "Submit", Result = CommandResult.KeepOpen() }
                 : new NoOpCommand();
             var hint = new ListItem(command)
             {
-                Title = canSubmit ? "Submit 2FA code" : "Two-Factor Authentication Required",
-                Subtitle = _errorMessage ?? (canSubmit
-                    ? "Press Enter to submit"
-                    : "Type your 6-8 digit code above and press Enter"),
+                Title = canSubmit ? $"Submit {typedNoun}" : "Two-Factor Authentication Required",
+                Subtitle = _errorMessage ?? (canSubmit ? "Press Enter to submit" : emptyHint),
                 Icon = new IconInfo("\uE8D7"),
             };
             if (_errorMessage != null)
                 hint.Tags = [new Tag("Error") { Foreground = ColorHelpers.FromRgb(0xED, 0x82, 0x74) }];
-            return WithDebugLog([hint]);
+            return WithDebugLog([hint, BuildBackToLoginItem()]);
         }
 
         if (_deviceVerificationRequired && _pendingEmail != null && _pendingPassword != null)
@@ -395,7 +394,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             };
             if (_errorMessage != null)
                 hint.Tags = [new Tag("Error") { Foreground = ColorHelpers.FromRgb(0xED, 0x82, 0x74) }];
-            return WithDebugLog([hint]);
+            return WithDebugLog([hint, BuildBackToLoginItem()]);
         }
 
         PlaceholderText = "Search your vault... (try is:fav, is:protected, folder:Work, has:totp, has:passkey, url:github)";
@@ -419,6 +418,45 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         BuildSetServerItem(),
         BuildLogoutItem(),
     ]);
+
+    internal static (string Placeholder, string TypedNoun, string EmptyHint, Func<string, bool> Validator) DescribeTwoFactorMethod(int? method) => method switch
+    {
+        0 => ("Enter your authenticator code...", "authenticator code", "Type the 6-digit code from your authenticator app", IsNumericCode),
+        1 => ("Enter the code sent to your email...", "email code", "Check your inbox for the code Bitwarden just sent", IsNumericCode),
+        3 => ("Touch your YubiKey...", "YubiKey OTP", "Touch your YubiKey to insert its one-time code", IsYubiKeyOtp),
+        _ => ("Enter your 2FA code...", "2FA code", "Type your 6-8 digit code above and press Enter", IsNumericCode),
+    };
+
+    private static bool IsNumericCode(string code) =>
+        code.Length >= 6 && code.Length <= 8 && long.TryParse(code, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out _);
+
+    private static bool IsYubiKeyOtp(string code) =>
+        code.Length >= 32 && code.Length <= 64 && code.All(c => char.IsLetterOrDigit(c));
+
+    private ListItem BuildBackToLoginItem() => new(new AnonymousCommand(OnBackToLoginRequested)
+    {
+        Name = "Back",
+        Result = CommandResult.KeepOpen(),
+    })
+    {
+        Title = "Back to login",
+        Subtitle = "Pick a different 2FA method or re-enter your credentials",
+        Icon = new IconInfo(""),
+    };
+
+    private void OnBackToLoginRequested()
+    {
+        DebugLogService.Log("Action", "User returned to login screen from 2FA prompt");
+        ClearSearchText();
+        _twoFactorRequired = false;
+        _deviceVerificationRequired = false;
+        _pendingEmail = null;
+        _pendingPassword = null;
+        _pendingTwoFactorMethod = null;
+        _errorMessage = null;
+        _currentItems = BuildUnauthenticatedItems();
+        RaiseItemsChanged();
+    }
 
     private ListItem BuildUnlockItem()
     {

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -82,6 +82,13 @@ internal sealed partial class LoginForm : FormContent
                 ]
             },
             {
+                "type": "TextBlock",
+                "text": "Using Duo Push or WebAuthn / FIDO2? Run `bw login <email>` in a terminal first, then return here and unlock with your master password.",
+                "wrap": true,
+                "isSubtle": true,
+                "size": "small"
+            },
+            {
                 "type": "ActionSet",
                 "actions": [
                     {

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -35,6 +35,13 @@ internal sealed partial class LoginForm : FormContent
   private string BuildTemplate()
   {
     var rememberChecked = _settings?.RememberSession.Value == true;
+    var customDataDir = BitwardenCliService.ResolveDataDirectory(
+        _settings?.CliDirectoryOverride.Value,
+        _settings?.UsePortableDataDirectory.Value ?? false,
+        _settings?.CliDataDirectoryOverride.Value);
+    var dataDirWarningBlock = customDataDir != null
+        ? BuildCustomDataDirWarningBlock(customDataDir)
+        : string.Empty;
     return $$"""
     {
         "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
@@ -50,6 +57,7 @@ internal sealed partial class LoginForm : FormContent
                 "wrap": true,
                 "style": "heading"
             },
+            {{dataDirWarningBlock}}
             {
                 "type": "Input.Text",
                 "label": "Email",
@@ -152,5 +160,19 @@ internal sealed partial class LoginForm : FormContent
     if (string.IsNullOrEmpty(raw) || string.Equals(raw, NoMethodValue, StringComparison.OrdinalIgnoreCase))
       return null;
     return int.TryParse(raw, out var method) ? method : 0;
+  }
+
+  internal static string BuildCustomDataDirWarningBlock(string dataDir)
+  {
+    var escaped = System.Text.Json.JsonEncodedText.Encode(dataDir).ToString();
+    return $$"""
+            {
+                "type": "TextBlock",
+                "text": "⚠ Custom CLI data directory: {{escaped}}\n\nFor an interactive `bw login` (Duo Push, WebAuthn) to share session with this extension, set `BITWARDENCLI_APPDATA_DIR` in your terminal to that path before running `bw login`. Otherwise the CLI will write auth state to a different location and the extension won't see it.",
+                "wrap": true,
+                "color": "attention",
+                "size": "small"
+            },
+            """;
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -83,15 +83,14 @@ internal sealed partial class LoginForm : FormContent
                 "value": "0",
                 "style": "compact",
                 "choices": [
-                    { "title": "Authenticator app (TOTP)", "value": "0" },
-                    { "title": "Email", "value": "1" },
+                    { "title": "Authenticator app", "value": "0" },
                     { "title": "YubiKey OTP", "value": "3" },
-                    { "title": "None (let CLI decide)", "value": "{{NoMethodValue}}" }
+                    { "title": "Auto-detect", "value": "{{NoMethodValue}}" }
                 ]
             },
             {
                 "type": "TextBlock",
-                "text": "Using Duo Push or WebAuthn / FIDO2? Run `bw login <email>` in a terminal first, then return here and unlock with your master password.",
+                "text": "Email 2FA isn't supported ([#157](https://github.com/hoobio/command-palette-bitwarden/issues/157)). For Duo Push or WebAuthn, run `bw login` in a terminal first, then unlock here with your master password.",
                 "wrap": true,
                 "isSubtle": true,
                 "size": "small"

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -10,7 +10,7 @@ internal sealed partial class LoginPage : ContentPage
 {
   private readonly LoginForm _form;
 
-  public LoginPage(BitwardenCliService service, BitwardenSettingsManager? settings = null, Action<string, string>? onSubmit = null)
+  public LoginPage(BitwardenCliService service, BitwardenSettingsManager? settings = null, Action<string, string, int?>? onSubmit = null)
   {
     Name = "Login";
     Title = "Login to Bitwarden";
@@ -23,9 +23,14 @@ internal sealed partial class LoginPage : ContentPage
 
 internal sealed partial class LoginForm : FormContent
 {
+  // Sentinel value in the ChoiceSet for "don't pass --method to bw login".
+  // Numeric values match Bitwarden's TwoFactorProviderType enum
+  // (libs/common/src/auth/enums/two-factor-provider-type.ts in bitwarden/clients).
+  private const string NoMethodValue = "none";
+
   private readonly BitwardenCliService _service;
   private readonly BitwardenSettingsManager? _settings;
-  private readonly Action<string, string>? _onSubmit;
+  private readonly Action<string, string, int?>? _onSubmit;
 
   private string BuildTemplate()
   {
@@ -64,6 +69,19 @@ internal sealed partial class LoginForm : FormContent
                 "placeholder": "Enter your master password"
             },
             {
+                "type": "Input.ChoiceSet",
+                "label": "Two-factor method (if prompted)",
+                "id": "TwoFactorMethod",
+                "value": "0",
+                "style": "compact",
+                "choices": [
+                    { "title": "Authenticator app (TOTP)", "value": "0" },
+                    { "title": "Email", "value": "1" },
+                    { "title": "YubiKey OTP", "value": "3" },
+                    { "title": "None (let CLI decide)", "value": "{{NoMethodValue}}" }
+                ]
+            },
+            {
                 "type": "ActionSet",
                 "actions": [
                     {
@@ -92,7 +110,7 @@ internal sealed partial class LoginForm : FormContent
     """;
   }
 
-  public LoginForm(BitwardenCliService service, BitwardenSettingsManager? settings = null, Action<string, string>? onSubmit = null)
+  public LoginForm(BitwardenCliService service, BitwardenSettingsManager? settings = null, Action<string, string, int?>? onSubmit = null)
   {
     _service = service;
     _settings = settings;
@@ -116,7 +134,16 @@ internal sealed partial class LoginForm : FormContent
       _settings.SaveSettings();
     }
 
-    _onSubmit?.Invoke(email, password);
+    int? twoFactorMethod = ParseTwoFactorMethod(formInput?["TwoFactorMethod"]?.GetValue<string>());
+
+    _onSubmit?.Invoke(email, password, twoFactorMethod);
     return CommandResult.GoBack();
+  }
+
+  internal static int? ParseTwoFactorMethod(string? raw)
+  {
+    if (string.IsNullOrEmpty(raw) || string.Equals(raw, NoMethodValue, StringComparison.OrdinalIgnoreCase))
+      return null;
+    return int.TryParse(raw, out var method) ? method : 0;
   }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -692,10 +692,12 @@ internal sealed class BitwardenCliService
       var args = $"login \"{sanitizedEmail}\" --passwordenv BW_MP";
       if (!string.IsNullOrEmpty(twoFactorCode))
       {
+        // Default to method 0 (authenticator/TOTP). Self-hosted servers can
+        // otherwise return a different default (e.g. email), which causes the
+        // CLI to reject a correct TOTP code as invalid. See issue #139.
         var sanitizedCode = twoFactorCode.Replace("\"", "");
-        args += twoFactorMethod.HasValue
-            ? $" --method {twoFactorMethod.Value} --code \"{sanitizedCode}\""
-            : $" --code \"{sanitizedCode}\"";
+        var method = twoFactorMethod ?? 0;
+        args += $" --method {method} --code \"{sanitizedCode}\"";
       }
       args += " --raw";
 
@@ -781,6 +783,7 @@ internal sealed class BitwardenCliService
           || stderr.Contains("two-factor", StringComparison.OrdinalIgnoreCase);
 
       var error = stderr;
+      DebugLogService.Log("Auth", $"Login failed (exit {exitCode}): {(string.IsNullOrEmpty(error) ? "(no stderr)" : error)}");
       return (false, string.IsNullOrEmpty(error) ? "Login failed" : error, needs2fa, false);
     }
     catch (Exception ex)

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -682,7 +682,11 @@ internal sealed class BitwardenCliService
     }
   }
 
-  public async Task<(bool Success, string? Error, bool TwoFactorRequired, bool DeviceVerificationRequired)> LoginAsync(string email, string password, string? twoFactorCode = null, int? twoFactorMethod = null)
+  // Default twoFactorMethod is 0 (Authenticator/TOTP). Self-hosted servers can
+  // otherwise return a different default (e.g. email) when --method is omitted,
+  // causing valid TOTP codes to be rejected as invalid (issue #139). Pass an
+  // explicit null to opt out and let the CLI auto-select.
+  public async Task<(bool Success, string? Error, bool TwoFactorRequired, bool DeviceVerificationRequired)> LoginAsync(string email, string password, string? twoFactorCode = null, int? twoFactorMethod = 0)
   {
     DebugLogService.Log("Auth", "LoginAsync started");
     DisposeDeviceVerificationProcess();
@@ -692,12 +696,10 @@ internal sealed class BitwardenCliService
       var args = $"login \"{sanitizedEmail}\" --passwordenv BW_MP";
       if (!string.IsNullOrEmpty(twoFactorCode))
       {
-        // Default to method 0 (authenticator/TOTP). Self-hosted servers can
-        // otherwise return a different default (e.g. email), which causes the
-        // CLI to reject a correct TOTP code as invalid. See issue #139.
         var sanitizedCode = twoFactorCode.Replace("\"", "");
-        var method = twoFactorMethod ?? 0;
-        args += $" --method {method} --code \"{sanitizedCode}\"";
+        args += twoFactorMethod.HasValue
+            ? $" --method {twoFactorMethod.Value} --code \"{sanitizedCode}\""
+            : $" --code \"{sanitizedCode}\"";
       }
       args += " --raw";
 

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -694,11 +694,18 @@ internal sealed class BitwardenCliService
     {
       var sanitizedEmail = email.Replace("\"", "");
       var args = $"login \"{sanitizedEmail}\" --passwordenv BW_MP";
+      // Only pass --method alongside --code on the second attempt. Tempting as it
+      // is to send --method on the first attempt too (so the CLI picks the right
+      // provider straight away and triggers Email 2FA's postTwoFactorEmail call),
+      // vaultwarden < 1.36 (and master at the time of writing) rejects
+      // postTwoFactorEmail with 422 because its SendEmailLoginData struct
+      // mandates deviceIdentifier, which the bw CLI doesn't include in the body.
+      // See vaultwarden src/api/core/two_factor/email.rs and issue #139 thread.
       if (!string.IsNullOrEmpty(twoFactorCode))
       {
         var sanitizedCode = twoFactorCode.Replace("\"", "");
         args += twoFactorMethod.HasValue
-            ? $" --method {twoFactorMethod.Value} --code \"{sanitizedCode}\""
+            ? $" --method {twoFactorMethod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)} --code \"{sanitizedCode}\""
             : $" --code \"{sanitizedCode}\"";
       }
       args += " --raw";


### PR DESCRIPTION
## Summary

Closes #139. `bw login` rejected valid TOTP codes when the CLI's provider heuristic picked the wrong method on multi-provider self-hosted accounts. The fix is twofold: default `--method 0` (Authenticator) when submitting a 2FA code, and surface a dropdown so users can pick their actual method when that default isn't right.

## Changes

- **Service:** `LoginAsync` now defaults `twoFactorMethod` to `0` when a code is supplied. Callers can pass `null` explicitly to opt out and let the CLI auto-select (matches the new dropdown's "Auto-detect" choice).
- **Login form:** new ChoiceSet with Authenticator app, YubiKey OTP, Auto-detect. Email is intentionally omitted with a footnote linking to #157.
- **2FA prompt UX:** placeholder, submit verb, empty-state hint, and input validator now adapt to the user's chosen method (numeric for TOTP/Email, alphanumeric for YubiKey).
- **Back to login** list item on the 2FA + device-verification screens, so users can recover from a wrong method choice or a bad code without restarting the palette.
- **Custom data-dir warning** on the login form when `UsePortableDataDirectory` or `CliDataDirectoryOverride` is set, naming the env var the user needs to set in their terminal for an interactive `bw login` to share state with the extension.
- **Footnote** pointing Duo Push / WebAuthn users at running `bw login` from a terminal first, then unlocking from the extension.
- **Auth log:** stderr + exit code now go to the debug log on login failure.
- **Email 2FA escape hatch:** the extension does not pass `--method` on the first login attempt. That avoids triggering `postTwoFactorEmail`, which vaultwarden < 1.37 rejects with 422 because its `SendEmailLoginData` struct mandates `deviceIdentifier` (filed upstream as dani-garcia/vaultwarden#7212). Tracked here as #157.

## Testing

- [x] Unit tests added/updated. `BitwardenCliService.Login*` (default method, explicit null, method-without-code), `LoginFormTests` (parse + warning block), `TwoFactorMethodDescriptorTests` (per-method copy + validator).
- [x] Manual testing in PowerToys Command Palette against vaultwarden 1.36.0: TOTP login, Auto-detect, YubiKey OTP, custom-data-dir warning, Back to login from a 2FA prompt with a bad code, Email 2FA not in dropdown.
- [x] Full suite passes locally in Release (`dotnet test -p:Platform=x64 -c Release`).

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build -c Release -p:Platform=x64`)
- [x] Changed `.cs` files meet the 50% coverage threshold (only `BitwardenCliService.cs` counts here; Pages/ is excluded per `coverage-exclusions.json` and the new logic in `HoobiBitwardenCommandPaletteExtensionPage.cs` is covered separately via the static `DescribeTwoFactorMethod` helper)
- [ ] Wiki docs updated — n/a

Closes #139
Tracks #157