### PR TITLE
feat: 🏷️ organization tag with deterministic colour and partial-name filter

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -441,6 +441,7 @@ public class BitwardenCliServiceMockedTests
     var folders = new JsonArray { new JsonObject { ["id"] = "f1", ["name"] = "Work" } };
     factory.Enqueue(new FakeCliProcess(stdout: folders.ToJsonString() + "\n", exitCode: 0));
     factory.Enqueue(new FakeCliProcess(stdout: items.ToJsonString() + "\n", exitCode: 0));
+    factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
 
     var cacheUpdated = false;
     svc.CacheUpdated += () => cacheUpdated = true;
@@ -475,9 +476,9 @@ public class BitwardenCliServiceMockedTests
     svc.SetSession("key");
     // sync
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
-    // RefreshCacheAsync → items
+    // RefreshCacheAsync → folders, items, organizations (parallel, dequeued in invocation order)
     factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
-    // RefreshCacheAsync → folders
+    factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
     factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
 
     await svc.SyncVaultAsync();
@@ -509,6 +510,8 @@ public class BitwardenCliServiceMockedTests
     factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
     // items query
     factory.Enqueue(new FakeCliProcess(stdout: "[{\"id\":\"1\",\"name\":\"Item\",\"type\":1,\"revisionDate\":\"2025-01-01T00:00:00Z\",\"login\":{\"username\":\"u\",\"password\":\"p\",\"uris\":[]}}]\n", exitCode: 0));
+    // organizations query
+    factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
 
     await svc.RefreshCacheAsync();
     var results = svc.SearchCached();

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
@@ -1067,6 +1067,99 @@ public class BitwardenCliServiceTests
   }
 
   [Fact]
+  public void ApplyFilter_Org_PartialNameMatch_CaseInsensitive()
+  {
+    var svc = new BitwardenCliService();
+    svc.LoadTestData([], [], new Dictionary<string, string> { ["org-1"] = "Test Organization" });
+    var result = svc.ApplyFilter(TestItems, ("org", "test")).ToList();
+    Assert.Single(result);
+    Assert.Equal("login-1", result[0].Id);
+  }
+
+  [Fact]
+  public void ApplyFilter_Org_FullNameMatch()
+  {
+    var svc = new BitwardenCliService();
+    svc.LoadTestData([], [], new Dictionary<string, string> { ["org-1"] = "Acme Corp" });
+    var result = svc.ApplyFilter(TestItems, ("org", "Acme Corp")).ToList();
+    Assert.Single(result);
+  }
+
+  [Theory]
+  [InlineData("org:\"Test Organization\"", "org", "Test Organization")]
+  [InlineData("org:'Test Organization'", "org", "Test Organization")]
+  [InlineData("folder:\"My Stuff\"", "folder", "My Stuff")]
+  [InlineData("url:\"github.com/foo\"", "url", "github.com/foo")]
+  public void ParseSearchFilters_QuotedValue_PreservesSpacesAndSlashes(string query, string expectedKey, string expectedValue)
+  {
+    var (filters, _) = BitwardenCliService.ParseSearchFilters(query);
+    Assert.Single(filters);
+    Assert.Equal(expectedKey, filters[0].Key);
+    Assert.Equal(expectedValue, filters[0].Value);
+  }
+
+  [Fact]
+  public void ParseSearchFilters_QuotedValue_WithTrailingFreeText()
+  {
+    var (filters, text) = BitwardenCliService.ParseSearchFilters("org:\"Test Organization\" github");
+    Assert.Single(filters);
+    Assert.Equal("Test Organization", filters[0].Value);
+    Assert.Equal("github", text);
+  }
+
+  [Fact]
+  public void ParseSearchFilters_BareKeyColon_ParsesAsEmptyValue()
+  {
+    var (filters, text) = BitwardenCliService.ParseSearchFilters("org:");
+    Assert.Single(filters);
+    Assert.Equal("org", filters[0].Key);
+    Assert.Equal("", filters[0].Value);
+    Assert.Null(text);
+  }
+
+  [Fact]
+  public void ApplyFilter_Org_EmptyValue_MatchesAllOrgItems()
+  {
+    var svc = new BitwardenCliService();
+    svc.LoadTestData([], [], new Dictionary<string, string> { ["org-1"] = "Acme Corp" });
+    var result = svc.ApplyFilter(TestItems, ("org", "")).ToList();
+    Assert.Single(result);
+    Assert.Equal("login-1", result[0].Id);
+  }
+
+  [Fact]
+  public void GetOrganizationName_Maps_Id_To_Name()
+  {
+    var svc = new BitwardenCliService();
+    svc.LoadTestData([], [], new Dictionary<string, string> { ["org-1"] = "Acme Corp" });
+    Assert.Equal("Acme Corp", svc.GetOrganizationName("org-1"));
+    Assert.Null(svc.GetOrganizationName("missing"));
+    Assert.Null(svc.GetOrganizationName(null));
+  }
+
+  [Fact]
+  public void ParseOrganizations_ValidJson_ReturnsIdToNameMap()
+  {
+    var json = "[{\"id\":\"org-1\",\"name\":\"Acme Corp\"},{\"id\":\"org-2\",\"name\":\"Globex\"}]";
+    var result = BitwardenCliService.ParseOrganizations(json);
+    Assert.Equal(2, result.Count);
+    Assert.Equal("Acme Corp", result["org-1"]);
+    Assert.Equal("Globex", result["org-2"]);
+  }
+
+  [Fact]
+  public void ParseOrganizations_EmptyArray_ReturnsEmptyMap()
+  {
+    Assert.Empty(BitwardenCliService.ParseOrganizations("[]"));
+  }
+
+  [Fact]
+  public void ParseOrganizations_InvalidJson_ReturnsEmptyMap()
+  {
+    Assert.Empty(BitwardenCliService.ParseOrganizations("not json"));
+  }
+
+  [Fact]
   public void ApplyFilter_Has_Totp()
   {
     var svc = CreateServiceWithFolders();

--- a/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
@@ -474,4 +474,114 @@ public class VaultItemHelperTests
     for (int i = 0; i < baseTags.Length; i++)
       Assert.Equal(baseTags[i].Text, fullTags[i].Text);
   }
+
+  [Fact]
+  public void BuildOrganizationTag_OffMode_ReturnsNull()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    Assert.Null(VaultItemHelper.BuildOrganizationTag(item, "Acme Corp", "off"));
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_NoOrgId_ReturnsNull()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login };
+    Assert.Null(VaultItemHelper.BuildOrganizationTag(item, "Acme Corp", "icon"));
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_NoName_ReturnsNull()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    Assert.Null(VaultItemHelper.BuildOrganizationTag(item, null, "icon"));
+    Assert.Null(VaultItemHelper.BuildOrganizationTag(item, "", "icon"));
+  }
+
+  [Theory]
+  [InlineData("Nintex", "N")]
+  [InlineData("Acme", "A")]
+  [InlineData("test", "T")]
+  [InlineData("Test Organization", "TO")]
+  [InlineData("Bitwarden Engineering Team", "BET")]
+  [InlineData("A B C D E", "ABC")]
+  [InlineData("  Spaced  Out  ", "SO")]
+  public void GetOrganizationInitials_Cases(string name, string expected)
+  {
+    Assert.Equal(expected, VaultItemHelper.GetOrganizationInitials(name));
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_InitialsMode_SingleWord_FirstLetter()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    var tag = VaultItemHelper.BuildOrganizationTag(item, "Nintex", "initials");
+    Assert.NotNull(tag);
+    Assert.Equal("N", tag!.Text);
+    Assert.Equal("Nintex", tag.ToolTip);
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_InitialsMode_MultiWord_Initials()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    var tag = VaultItemHelper.BuildOrganizationTag(item, "Test Organization", "initials");
+    Assert.NotNull(tag);
+    Assert.Equal("TO", tag!.Text);
+    Assert.Equal("Test Organization", tag.ToolTip);
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_NameMode_ShortName_NotTruncated()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    var tag = VaultItemHelper.BuildOrganizationTag(item, "Acme Corp", "name");
+    Assert.NotNull(tag);
+    Assert.Equal("Acme Corp", tag!.Text);
+    Assert.Equal("Acme Corp", tag.ToolTip);
+  }
+
+  [Fact]
+  public void BuildOrganizationTag_NameMode_LongName_TruncatedWithTooltip()
+  {
+    var item = new BitwardenItem { Id = "i", Type = BitwardenItemType.Login, OrganizationId = "org-1" };
+    var full = "Some Very Long Organisation Name Indeed";
+    var tag = VaultItemHelper.BuildOrganizationTag(item, full, "name");
+    Assert.NotNull(tag);
+    Assert.Equal(21, tag!.Text.Length);
+    Assert.EndsWith("…", tag.Text, StringComparison.Ordinal);
+    Assert.Equal(full, tag.ToolTip);
+  }
+
+  [Fact]
+  public void GetOrganizationColor_SameId_SameColor()
+  {
+    var a = VaultItemHelper.GetOrganizationColor("d3aaa1f4-1234-4abc-9876-fedcba987654");
+    var b = VaultItemHelper.GetOrganizationColor("d3aaa1f4-1234-4abc-9876-fedcba987654");
+    Assert.Equal(a.Color.R, b.Color.R);
+    Assert.Equal(a.Color.G, b.Color.G);
+    Assert.Equal(a.Color.B, b.Color.B);
+  }
+
+  [Fact]
+  public void GetOrganizationColor_DifferentIds_SpreadAcrossPalette()
+  {
+    var ids = new[]
+    {
+      "00000000-0000-0000-0000-000000000001",
+      "00000000-0000-0000-0000-000000000002",
+      "00000000-0000-0000-0000-000000000003",
+      "00000000-0000-0000-0000-000000000004",
+      "00000000-0000-0000-0000-000000000005",
+      "00000000-0000-0000-0000-000000000006",
+      "00000000-0000-0000-0000-000000000007",
+      "00000000-0000-0000-0000-000000000008",
+    };
+    var distinctColors = ids
+      .Select(VaultItemHelper.GetOrganizationColor)
+      .Select(c => (c.Color.R, c.Color.G, c.Color.B))
+      .Distinct()
+      .Count();
+    // 8 distinct GUIDs should hit at least 3 distinct palette entries (loose lower bound).
+    Assert.True(distinctColors >= 3, $"Expected colour spread, got {distinctColors} distinct colours");
+  }
 }

--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -95,9 +95,9 @@ internal static partial class VaultItemHelper
     return items.ToArray();
   }
 
-  internal static Tag[] BuildTags(BitwardenItem item, bool showWatchtowerTags = true, ForegroundContext? context = null, bool showContextTag = true, string totpTagStyle = "off", bool showPasskeyTag = true, bool showProtectedTag = true)
+  internal static Tag[] BuildTags(BitwardenItem item, bool showWatchtowerTags = true, ForegroundContext? context = null, bool showContextTag = true, string totpTagStyle = "off", bool showPasskeyTag = true, bool showProtectedTag = true, string? organizationName = null, string organizationTagStyle = "off")
   {
-    var baseTags = BuildBaseTags(item, showWatchtowerTags, context, showContextTag, showPasskeyTag, showProtectedTag);
+    var baseTags = BuildBaseTags(item, showWatchtowerTags, context, showContextTag, showPasskeyTag, showProtectedTag, organizationName, organizationTagStyle);
 
     if (totpTagStyle != "off" && item.HasTotp)
     {
@@ -109,7 +109,7 @@ internal static partial class VaultItemHelper
     return baseTags;
   }
 
-  internal static Tag[] BuildBaseTags(BitwardenItem item, bool showWatchtowerTags = true, ForegroundContext? context = null, bool showContextTag = true, bool showPasskeyTag = true, bool showProtectedTag = true)
+  internal static Tag[] BuildBaseTags(BitwardenItem item, bool showWatchtowerTags = true, ForegroundContext? context = null, bool showContextTag = true, bool showPasskeyTag = true, bool showProtectedTag = true, string? organizationName = null, string organizationTagStyle = "off")
   {
     var tags = new List<Tag>();
 
@@ -132,10 +132,72 @@ internal static partial class VaultItemHelper
     if (showPasskeyTag && item.HasPasskey)
       tags.Add(new Tag("Passkey") { Foreground = ColorHelpers.FromRgb(0xA0, 0xC4, 0xFF) });
 
+    var orgTag = BuildOrganizationTag(item, organizationName, organizationTagStyle);
+    if (orgTag != null)
+      tags.Add(orgTag);
+
     if (showWatchtowerTags)
       AddWatchtowerTags(tags, item);
 
     return tags.Count > 0 ? [.. tags] : [];
+  }
+
+  private static readonly OptionalColor[] OrganizationColors =
+  [
+    ColorHelpers.FromRgb(0xB7, 0x9C, 0xE6),
+    ColorHelpers.FromRgb(0xE2, 0xA8, 0xE3),
+    ColorHelpers.FromRgb(0xF0, 0xA0, 0xB8),
+    ColorHelpers.FromRgb(0xFF, 0xC0, 0x9E),
+    ColorHelpers.FromRgb(0xD0, 0xE0, 0x7A),
+    ColorHelpers.FromRgb(0x87, 0xE0, 0xB5),
+    ColorHelpers.FromRgb(0x7B, 0xD0, 0xE5),
+    ColorHelpers.FromRgb(0xA0, 0xA8, 0xE8),
+  ];
+
+  internal static OptionalColor GetOrganizationColor(string organizationId)
+  {
+    unchecked
+    {
+      uint hash = 2166136261;
+      foreach (var c in organizationId)
+        hash = (hash ^ c) * 16777619;
+      return OrganizationColors[hash % (uint)OrganizationColors.Length];
+    }
+  }
+
+  internal static Tag? BuildOrganizationTag(BitwardenItem item, string? organizationName, string organizationTagStyle)
+  {
+    if (organizationTagStyle == "off") return null;
+    if (string.IsNullOrEmpty(item.OrganizationId)) return null;
+    if (string.IsNullOrEmpty(organizationName))
+    {
+      DebugLogService.Log("OrgTag", $"Skipped org tag for item {item.Id}: orgId={item.OrganizationId} has no resolved name");
+      return null;
+    }
+
+    var color = GetOrganizationColor(item.OrganizationId);
+    var text = organizationTagStyle == "initials"
+      ? GetOrganizationInitials(organizationName)
+      : (organizationName.Length > 20 ? organizationName[..20] + "\u2026" : organizationName);
+    return new Tag(text)
+    {
+      ToolTip = organizationName,
+      Foreground = color,
+    };
+  }
+
+  internal static string GetOrganizationInitials(string name)
+  {
+    var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+    if (parts.Length <= 1)
+      return char.ToUpperInvariant(name.Trim()[0]).ToString();
+    var sb = new System.Text.StringBuilder(3);
+    foreach (var part in parts)
+    {
+      if (sb.Length >= 3) break;
+      sb.Append(char.ToUpperInvariant(part[0]));
+    }
+    return sb.ToString();
   }
 
   internal static Tag? BuildTotpTag(string totpSecret) => GetLiveTotpTag(totpSecret);

--- a/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.csproj
+++ b/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.csproj
@@ -117,12 +117,25 @@
   <Target Name="StampPackageIdentityName" BeforeTargets="Build;_ConvertItems">
     <PropertyGroup>
       <AppxManifestPath>$(MSBuildProjectDirectory)\Package.appxmanifest</AppxManifestPath>
+      <VersionTxtPath>$(MSBuildProjectDirectory)\..\version.txt</VersionTxtPath>
       <BasePackageName>Hoobi.BitwardenCommandPaletteExtension</BasePackageName>
       <FullPackageName>$(BasePackageName)$(PackageNameSuffix)</FullPackageName>
       <BaseDisplayName>Command Palette Extension for Bitwarden</BaseDisplayName>
       <FullDisplayName>$(BaseDisplayName)$(DisplayNameSuffix)</FullDisplayName>
     </PropertyGroup>
-    <Message Text="Stamping package identity: $(FullPackageName) with display name: $(FullDisplayName)" Importance="high" />
+    <ReadLinesFromFile File="$(VersionTxtPath)" Condition="Exists('$(VersionTxtPath)')">
+      <Output TaskParameter="Lines" ItemName="VersionTxtLines" />
+    </ReadLinesFromFile>
+    <PropertyGroup>
+      <SemVerFromFile>@(VersionTxtLines)</SemVerFromFile>
+      <FourPartVersion Condition="'$(SemVerFromFile)' != ''">$(SemVerFromFile).0</FourPartVersion>
+    </PropertyGroup>
+    <Message Text="Stamping package identity: $(FullPackageName) with display name: $(FullDisplayName) at version: $(FourPartVersion)" Importance="high" />
+    <XmlPoke XmlInputPath="$(AppxManifestPath)"
+             Condition="'$(FourPartVersion)' != ''"
+             Query="/ns:Package/ns:Identity/@Version"
+             Value="$(FourPartVersion)"
+             Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/appx/manifest/foundation/windows10'/&gt;" />
     <XmlPoke XmlInputPath="$(AppxManifestPath)"
              Query="/ns:Package/ns:Identity/@Name"
              Value="$(FullPackageName)"

--- a/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
+++ b/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap uap3 rescap">
-  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.8.0.0" />
+  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.9.2.0" />
   <Properties>
     <DisplayName>Command Palette Extension for Bitwarden (Dev)</DisplayName>
     <PublisherDisplayName>Hoobi</PublisherDisplayName>

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -571,6 +571,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         var showPasskeyTag = _settings?.ShowPasskeyTag.Value != false;
         var showProtectedTag = _settings?.ShowProtectedTag.Value != false;
         var showWebsiteIcons = _settings?.ShowWebsiteIcons.Value != false;
+        var organizationTagStyle = _settings?.OrganizationTagStyle.Value ?? "name";
         var totpTracked = new List<(ListItem, BitwardenItem, Tag[])>();
 
         var contextLimit = int.TryParse(_settings?.ContextItemLimit.Value, out var lv) ? lv : 3;
@@ -608,11 +609,12 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 // When capContextTags is true, ContextScore was already evaluated above — pass context: null
                 // and showContextTag: allowContextTag to avoid a redundant ContextScore call in BuildTags/BuildBaseTags.
                 var contextForTags = capContextTags ? null : _context;
-                var listItem = BuildListItem(item, showWatchtower, allowContextTag, totpTagStyle, showPasskeyTag, showProtectedTag, showWebsiteIcons, contextForTags, iconPriority++);
+                var organizationName = organizationTagStyle != "off" ? _service?.GetOrganizationName(item.OrganizationId) : null;
+                var listItem = BuildListItem(item, showWatchtower, allowContextTag, totpTagStyle, showPasskeyTag, showProtectedTag, showWebsiteIcons, contextForTags, iconPriority++, organizationName, organizationTagStyle);
                 list.Add(listItem);
                 if (totpTagStyle == "live" && item.HasTotp)
                 {
-                    var baseTags = VaultItemHelper.BuildBaseTags(item, showWatchtower, contextForTags, allowContextTag, showPasskeyTag, showProtectedTag);
+                    var baseTags = VaultItemHelper.BuildBaseTags(item, showWatchtower, contextForTags, allowContextTag, showPasskeyTag, showProtectedTag, organizationName, organizationTagStyle);
                     totpTracked.Add((listItem, item, baseTags));
                 }
             }
@@ -639,7 +641,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         return list.ToArray();
     }
 
-    private ListItem BuildListItem(BitwardenItem item, bool showWatchtower, bool showContextTag, string totpTagStyle, bool showPasskeyTag, bool showProtectedTag, bool showWebsiteIcons = true, ForegroundContext? context = null, int iconPriority = int.MaxValue)
+    private ListItem BuildListItem(BitwardenItem item, bool showWatchtower, bool showContextTag, string totpTagStyle, bool showPasskeyTag, bool showProtectedTag, bool showWebsiteIcons = true, ForegroundContext? context = null, int iconPriority = int.MaxValue, string? organizationName = null, string organizationTagStyle = "off")
     {
         var listItem = new ListItem(VaultItemHelper.GetDefaultCommand(item, _service))
         {
@@ -649,7 +651,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             MoreCommands = VaultItemHelper.BuildContextItems(item, _service),
         };
 
-        var tags = VaultItemHelper.BuildTags(item, showWatchtower, context, showContextTag, totpTagStyle, showPasskeyTag, showProtectedTag);
+        var tags = VaultItemHelper.BuildTags(item, showWatchtower, context, showContextTag, totpTagStyle, showPasskeyTag, showProtectedTag, organizationName, organizationTagStyle);
         if (tags.Length > 0)
             listItem.Tags = tags;
 

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -53,6 +53,7 @@ internal sealed class BitwardenCliService
 
   private VaultStatus? _lastStatus;
   private Dictionary<string, string> _folders = [];
+  private Dictionary<string, string> _organizations = [];
 
   private Timer? _autoLockTimer;
   private TimeSpan _autoLockTimeout;
@@ -126,6 +127,11 @@ internal sealed class BitwardenCliService
     get { lock (_cacheLock) return _folders; }
   }
 
+  internal IReadOnlyDictionary<string, string> Organizations
+  {
+    get { lock (_cacheLock) return _organizations; }
+  }
+
   public event Action? CacheUpdated;
   public event Action? StatusChanged;
   public event Action? WarmupCompleted;
@@ -155,9 +161,9 @@ internal sealed class BitwardenCliService
     }
   }
 
-  internal void LoadTestData(List<BitwardenItem> items, Dictionary<string, string> folders)
+  internal void LoadTestData(List<BitwardenItem> items, Dictionary<string, string> folders, Dictionary<string, string>? organizations = null)
   {
-    lock (_cacheLock) { _cache = items; _folders = folders; _cacheLoaded = true; }
+    lock (_cacheLock) { _cache = items; _folders = folders; _organizations = organizations ?? []; _cacheLoaded = true; }
   }
 
   private void ApplyAutoLockSetting()
@@ -1068,6 +1074,13 @@ internal sealed class BitwardenCliService
       return _folders.GetValueOrDefault(folderId);
   }
 
+  internal string? GetOrganizationName(string? organizationId)
+  {
+    if (organizationId == null) return null;
+    lock (_cacheLock)
+      return _organizations.GetValueOrDefault(organizationId);
+  }
+
   private static int ContextBoost(BitwardenItem item, ForegroundContext? context)
   {
     if (context == null)
@@ -1086,24 +1099,23 @@ internal sealed class BitwardenCliService
       return (filters, query.Trim());
 
     var remaining = new System.Text.StringBuilder();
-    foreach (var token in query.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+    foreach (var token in TokenizeRespectingQuotes(query))
     {
       var colonIdx = token.IndexOf(':');
-      if (colonIdx > 0 && colonIdx < token.Length - 1)
+      if (colonIdx > 0)
       {
         var key = token[..colonIdx].ToLowerInvariant();
-        var value = token[(colonIdx + 1)..];
+        var value = colonIdx < token.Length - 1 ? token[(colonIdx + 1)..] : "";
         if (IsKnownFilter(key))
         {
           filters.Add((key, value));
           continue;
         }
-      }
-
-      if (token.StartsWith("has:", StringComparison.OrdinalIgnoreCase) && token.Length > 4)
-      {
-        filters.Add(("has", token[4..].ToLowerInvariant()));
-        continue;
+        if (key == "has")
+        {
+          filters.Add(("has", value.ToLowerInvariant()));
+          continue;
+        }
       }
 
       if (remaining.Length > 0) remaining.Append(' ');
@@ -1114,7 +1126,58 @@ internal sealed class BitwardenCliService
     return (filters, text);
   }
 
+  internal static IEnumerable<string> TokenizeRespectingQuotes(string query)
+  {
+    var buffer = new System.Text.StringBuilder();
+    var quoteChar = '\0';
+    foreach (var c in query)
+    {
+      if (quoteChar != '\0')
+      {
+        if (c == quoteChar) quoteChar = '\0';
+        else buffer.Append(c);
+      }
+      else if (c == '"' || c == '\'')
+      {
+        quoteChar = c;
+      }
+      else if (c == ' ')
+      {
+        if (buffer.Length > 0)
+        {
+          yield return buffer.ToString();
+          buffer.Clear();
+        }
+      }
+      else
+      {
+        buffer.Append(c);
+      }
+    }
+    if (buffer.Length > 0)
+      yield return buffer.ToString();
+  }
+
   internal static bool IsKnownFilter(string key) => key is "folder" or "url" or "host" or "type" or "org" or "is";
+
+  internal IEnumerable<BitwardenItem> ApplyOrgFilter(IEnumerable<BitwardenItem> items, string value)
+  {
+    DebugLogService.Log("Filter", $"ApplyOrgFilter: value='{value}', orgs cached={Organizations.Count}");
+    var matches = 0;
+    foreach (var i in items)
+    {
+      if (i.OrganizationId == null) continue;
+      var name = GetOrganizationName(i.OrganizationId);
+      var matched = (name != null && name.Contains(value, StringComparison.OrdinalIgnoreCase))
+        || i.OrganizationId.Contains(value, StringComparison.OrdinalIgnoreCase);
+      if (matched)
+      {
+        matches++;
+        yield return i;
+      }
+    }
+    DebugLogService.Log("Filter", $"ApplyOrgFilter: returned {matches} items for value='{value}'");
+  }
 
   internal IEnumerable<BitwardenItem> ApplyFilter(IEnumerable<BitwardenItem> items, (string Key, string Value) filter) => filter.Key switch
   {
@@ -1127,7 +1190,7 @@ internal sealed class BitwardenCliService
         i.Type == BitwardenItemType.Login && i.Uris.Any(u => u.Uri.Contains(filter.Value, StringComparison.OrdinalIgnoreCase))),
     "type" => items.Where(i => i.Type.ToString().Equals(filter.Value, StringComparison.OrdinalIgnoreCase)
         || ((int)i.Type).ToString(System.Globalization.CultureInfo.InvariantCulture) == filter.Value),
-    "org" => items.Where(i => i.OrganizationId != null && i.OrganizationId.Contains(filter.Value, StringComparison.OrdinalIgnoreCase)),
+    "org" => ApplyOrgFilter(items, filter.Value),
     "has" => filter.Value switch
     {
       "totp" or "otp" or "2fa" or "mfa" => items.Where(i => i.HasTotp),
@@ -1186,14 +1249,17 @@ internal sealed class BitwardenCliService
     {
       var foldersTask = RunCliAsync("list folders");
       var itemsTask = RunCliAsync("list items");
-      await Task.WhenAll(foldersTask, itemsTask);
+      var organizationsTask = RunCliAsync("list organizations");
+      await Task.WhenAll(foldersTask, itemsTask, organizationsTask);
 
       var folders = ParseFolders(await foldersTask);
       var items = ParseItems(await itemsTask);
-      DebugLogService.Log("Cache", $"Cache refreshed: {items.Count} items, {folders.Count} folders");
+      var organizations = ParseOrganizations(await organizationsTask);
+      DebugLogService.Log("Cache", $"Cache refreshed: {items.Count} items, {folders.Count} folders, {organizations.Count} organizations");
       lock (_cacheLock)
       {
         _folders = folders;
+        _organizations = organizations;
         _cache = items;
         _cacheLoaded = true;
         _lastRefresh = DateTime.UtcNow;
@@ -1767,6 +1833,29 @@ internal sealed class BitwardenCliService
     catch (Exception ex)
     {
       DebugLogService.Log("Cache", $"ParseFolders failed: {ex.GetType().Name}: {ex.Message}");
+    }
+    return result;
+  }
+
+  internal static Dictionary<string, string> ParseOrganizations(string json)
+  {
+    var result = new Dictionary<string, string>(StringComparer.Ordinal);
+    try
+    {
+      var array = JsonNode.Parse(json)?.AsArray();
+      if (array == null) return result;
+
+      foreach (var node in array)
+      {
+        var id = node?["id"]?.GetValue<string>();
+        var name = node?["name"]?.GetValue<string>();
+        if (!string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(name))
+          result[id] = name;
+      }
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Cache", $"ParseOrganizations failed: {ex.GetType().Name}: {ex.Message}");
     }
     return result;
   }

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
@@ -89,6 +89,16 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
             new("Live (show live code + countdown)", "live"),
         ]);
 
+    public ChoiceSetSetting OrganizationTagStyle { get; } = new(
+        "organizationTagStyle",
+        "Organization Tag Style",
+        "Display an organization tag on vault items owned by a Bitwarden organization. Each organization gets a stable colour, deterministic from the organization ID",
+        [
+            new("Initials (compact 1-3 char badge)", "initials"),
+            new("Name (full organization name)", "name"),
+            new("Off", "off"),
+        ]);
+
     public ChoiceSetSetting AutoLockTimeout { get; } = new(
         "autoLockTimeout",
         "Auto-Lock Timeout",
@@ -186,6 +196,7 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         FilePath = settingsFilePath ?? Path.Combine(SettingsDir, "settings.json");
         ContextItemLimit.Value = "3";
         TotpTagStyle.Value = "static";
+        OrganizationTagStyle.Value = "name";
         BackgroundRefresh.Value = "5";
         RepromptGracePeriod.Value = "60";
         Settings.Add(new SectionHeaderSetting("_section_auth", "Authentication", separator: false));
@@ -201,6 +212,7 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         Settings.Add(ShowProtectedTag);
         Settings.Add(ShowPasskeyTag);
         Settings.Add(TotpTagStyle);
+        Settings.Add(OrganizationTagStyle);
         Settings.Add(BackgroundRefresh);
 
         Settings.Add(new SectionHeaderSetting("_section_context", "Context Awareness"));
@@ -290,6 +302,7 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         yield return (ShowProtectedTag.Key, (object?)ShowProtectedTag.Value);
         yield return (ShowPasskeyTag.Key, ShowPasskeyTag.Value);
         yield return (TotpTagStyle.Key, TotpTagStyle.Value);
+        yield return (OrganizationTagStyle.Key, OrganizationTagStyle.Value);
         yield return (BackgroundRefresh.Key, BackgroundRefresh.Value);
         yield return (ContextAwareness.Key, ContextAwareness.Value);
         yield return (ShowContextTag.Key, ShowContextTag.Value);

--- a/docs/Search-and-Filtering.md
+++ b/docs/Search-and-Filtering.md
@@ -22,7 +22,7 @@ Use prefix syntax to narrow results. Filters can be combined freely.
 | `has:notes` | `has:notes` | Items with notes |
 | `url:<partial>` / `host:<partial>` | `url:github.com` | Login items matching a URL |
 | `type:<type>` | `type:login` | Filter by item type |
-| `org:<id>` | `org:myorg` | Filter by organization |
+| `org:<name>` | `org:nintex` | Filter by organization name (partial, case-insensitive) or organization ID |
 | `is:weak` | `is:weak` | Logins with a password shorter than 8 characters |
 | `is:old` / `is:stale` | `is:old` | Logins whose password hasn't changed in over a year |
 | `is:insecure` / `is:http` | `is:insecure` | Logins with an `http://` URI |
@@ -39,6 +39,18 @@ is:fav has:totp folder:Personal
 ```
 
 This shows only favorite items with TOTP that are in a folder containing "Personal".
+
+### Quoted Values
+
+Wrap a filter value in single or double quotes to include spaces:
+
+```
+org:"Test Organization"
+folder:'My Personal Stuff'
+url:"github.com/foo"
+```
+
+Quotes apply to every filter, not just `org:`.
 
 ## Sort Order
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -78,6 +78,15 @@ Open settings from the gear icon in the vault browser. All settings take effect 
 | **Options** | Off, Static (show 2FA badge only), Live (show live code + countdown) |
 | **Description** | Controls how TOTP-enabled vault items are tagged. **Off** hides the tag entirely, **Static** shows a "2FA" badge, and **Live** displays the current code with a countdown timer that updates every second. |
 
+### Organization Tag Style
+
+| | |
+|---|---|
+| **Type** | Choice (dropdown) |
+| **Default** | Name |
+| **Options** | Initials (compact 1-3 char badge), Name (full organization name), Off |
+| **Description** | Controls how items belonging to a Bitwarden organization are tagged. **Initials** shows a compact avatar-style badge (single-word orgs get one letter, e.g. `Nintex` → `N`; multi-word orgs get up to three initials, e.g. `Test Organization` → `TO`). **Name** shows the organization name on the tag (truncated to 20 characters). **Off** hides the tag entirely. Each organization gets a stable, deterministic colour from a pastel palette, so two items from the same organization always render in the same colour. |
+
 ### Context Items Limit
 
 | | |

--- a/docs/Watchtower-Tags.md
+++ b/docs/Watchtower-Tags.md
@@ -26,4 +26,5 @@ On a single item, tags appear in this order:
 4. **Context** (blue) - matches an open app/browser tab
 5. **2FA / TOTP** (green) - live code or static badge
 6. **Passkey** (blue) - item has a FIDO2 passkey
-7. **Weak**, **Old**, **Insecure URL** (Watchtower)
+7. **Initials / org name** - item belongs to a Bitwarden organization, shown as an avatar-style initials badge (e.g. `N` for Nintex, `TO` for Test Organization) or the full organization name. Colour is stable per organization (deterministic palette). Style configurable via **Settings > Organization Tag Style**
+8. **Weak**, **Old**, **Insecure URL** (Watchtower)


### PR DESCRIPTION
## Summary

Closes #160. First concrete step toward #159.

## Changes

- New **Organization Tag Style** setting (`Initials` / `Name` / `Off`, default `Name`). Items owned by a Bitwarden organisation get a coloured tag.
- Deterministic per-org colour: FNV-1a hash of the organisation GUID indexed into an 8-entry pastel palette, so two items from the same org always render the same colour and the same org always lands on the same colour across reboots.
- Initials mode follows the avatar-fallback convention: `Nintex` → `N`, `Test Organization` → `TO`, `Bitwarden Engineering Team` → `BET` (capped at 3).
- `org:` search filter now matches partial organisation **name** (case-insensitive), in addition to the GUID. `org:test` → items in `Test Organization`.
- Parser supports quoted values for every filter: `folder:"My Stuff"`, `org:'Test Organization'`, `url:"github.com/foo"`.
- Bare-key syntax: `org:` returns every item with any organisation. Works for all filter keys.
- `RefreshCacheAsync` now also calls `bw list organizations` in parallel with `list items` / `list folders` and exposes a name lookup via `BitwardenCliService.GetOrganizationName`.
- Build: `Package.appxmanifest` `Identity/@Version` is now stamped at build time from `version.txt` (mirrors what CI already does), removing the need for manual manifest bumps in release-please PRs.
- Docs: updated `Settings.md`, `Watchtower-Tags.md`, `Search-and-Filtering.md`.

## Testing

- [x] Unit tests added/updated (29 new tests covering org tag building, colour determinism, partial-name filter, quoted values, bare-key, parse helpers)
- [x] Manual testing with PowerToys Command Palette (Initials, Name, Off; `org:test`, `org:"Test Organization"`, `org:` bare)
- [x] Existing tests pass (491/492 - the one failure is pre-existing `RecordVerification_DoesNotPersistAcrossProcesses` flaking on a leftover `grace.json` from real extension use, unrelated to this change)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build -c Debug -p:Platform=x64`)
- [x] Wiki docs updated

## Notes / known limitations

- Tag tooltips are wired in the toolkit but **not honoured by cmdpal** because the `ItemsRepeater` holding tags has `IsHitTestVisible="False"`. Worth a separate PowerToys issue. With no tooltip, Initials mode trades full-name discoverability for compactness; Name mode is the default for that reason.
- The Fluent Icons `Tag.Icon` path also doesn't render reliably (`IconBox.SourceRequested` is wired in cmdpal's Tag, but PUA glyphs were inconsistent in practice). Tag.Text with a per-org colour was the only reliable path.