### PR TITLE
fix: 🐛 verify session with list folders, not just sync

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -57,6 +57,8 @@ public class BitwardenCliServiceMockedTests
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
     // VerifySessionAsync → sync → "Syncing complete."
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
+    // VerifySessionAsync → list folders → empty JSON array proves decryption worked
+    factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
     var result = await svc.GetVaultStatusAsync();
     Assert.Equal(VaultStatus.Unlocked, result);
   }
@@ -68,8 +70,10 @@ public class BitwardenCliServiceMockedTests
     svc.SetSession("bad-session");
     // IsCliAvailable
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
-    // VerifySessionAsync → sync fails (no "Syncing complete." line)
-    factory.Enqueue(new FakeCliProcess(stdout: "error\n", exitCode: 1));
+    // VerifySessionAsync → sync succeeds (sync only needs auth, not unlock)
+    factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
+    // VerifySessionAsync → list folders fails because session is dead → HandleInvalidSession + throw
+    factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "Vault is locked.\n", exitCode: 1));
     // FetchStatusAsync → RunCliAsync("status")
     factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"locked\"}\n", exitCode: 0));
     var result = await svc.GetVaultStatusAsync();
@@ -658,6 +662,7 @@ public class BitwardenCliServiceMockedTests
     svc.SetSession("test-key");
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
+    factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
     await svc.GetVaultStatusAsync();
     Assert.NotNull(factory.LastPsi);
     Assert.Equal(System.Text.Encoding.UTF8, factory.LastPsi!.StandardOutputEncoding);

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -410,24 +410,22 @@ internal sealed partial class BitwardenCliService
 
   private async Task<bool> VerifySessionAsync()
   {
-    using var lease = NewCliLease("sync", CliTimeoutMs);
     try
     {
-      DebugLogService.Log("Verify", "Running bw sync to verify session");
-      string? line;
-      while ((line = await lease.Process.StandardOutput.ReadLineAsync(lease.Token)) != null)
-      {
-        DebugLogService.Log("Verify", $"sync stdout: {line}");
-        if (line.Contains("Syncing complete.", StringComparison.OrdinalIgnoreCase))
-        {
-          // Detach instead of kill: a force-killed `bw sync` leaves data.json in a half-written
-          // state, which makes the very next `bw list` fail validateUserKey → "Vault is locked.".
-          DebugLogService.Log("Verify", "Session verified successfully, detaching for graceful drain");
-          lease.Detach();
-          return true;
-        }
-      }
-      DebugLogService.Log("Verify", "sync completed without 'Syncing complete.' line");
+      // bw sync only requires authentication, not an unlocked vault: a stale
+      // session key will still pull the encrypted blob just fine and print
+      // "Syncing complete.", so sync alone is a false-positive session check.
+      // Pair it with a decryption-requiring call to actually exercise the
+      // session key. bw list folders is the cheapest such call - tiny payload
+      // but it has to decrypt to render. If the session is dead, RunCliAsync
+      // sees "Vault is locked" in stderr, fires HandleInvalidSession (which
+      // clears _sessionKey), and throws - the catch below returns false.
+      DebugLogService.Log("Verify", "Running bw sync");
+      await RunCliAsync("sync", CliTimeoutMs, "Syncing complete.");
+      DebugLogService.Log("Verify", "Running bw list folders to verify session");
+      await RunCliAsync("list folders");
+      DebugLogService.Log("Verify", "Session verified successfully");
+      return true;
     }
     catch (Exception ex)
     {
@@ -479,20 +477,21 @@ internal sealed partial class BitwardenCliService
     _sessionKey = stored;
     if (!await VerifySessionAsync())
     {
-      // Same policy as GetVaultStatusCoreAsync: a single bw sync failure can
-      // be transient (network blip, slow CLI startup), so don't burn the
-      // saved credential here. HandleInvalidSession clears it on real CLI
-      // errors that confirm the session is gone.
+      // Same policy as GetVaultStatusCoreAsync: a transient verify failure
+      // (network blip, slow CLI startup) shouldn't burn the saved credential
+      // here. HandleInvalidSession clears it on real CLI errors that confirm
+      // the session is gone.
       DebugLogService.Log("Restore", "Stored session verification failed (preserving credential for retry)");
       return false;
     }
 
-    // bw sync can take seconds. A concurrent HandleInvalidSession (e.g. an
-    // in-flight warmup `bw list` returning "Vault is locked") may have nulled
-    // _sessionKey while we were verifying. The verify just proved the stored
-    // credential is valid, so re-assert it before SetStatus/RefreshCacheAsync,
-    // otherwise IsUnlocked stays false and the cache refresh silently skips,
-    // leaving the page stuck on "Retrieving items from vault...".
+    // The verify takes seconds (sync + list folders). A concurrent
+    // HandleInvalidSession (e.g. an in-flight warmup `bw list` returning
+    // "Vault is locked") may have nulled _sessionKey while we were verifying.
+    // The verify just proved the stored credential is valid, so re-assert it
+    // before SetStatus/RefreshCacheAsync, otherwise IsUnlocked stays false
+    // and the cache refresh silently skips, leaving the page stuck on
+    // "Retrieving items from vault...".
     _sessionKey = stored;
     SetStatus(VaultStatus.Unlocked);
     StatusChanged?.Invoke();


### PR DESCRIPTION
## Summary

Stop the unlock/lock flicker when a stored session has gone stale: `bw sync` succeeds against an authenticated-but-locked vault, so it was a false-positive session check. Pair it with `bw list folders` to actually exercise decryption.

## Changes

- `VerifySessionAsync`: run `bw sync` then `bw list folders` via `RunCliAsync`. If the session is dead, `RunCliAsync` catches "Vault is locked" in stderr, fires `HandleInvalidSession`, and throws — verify correctly returns false. No more thrash from `TryRestoreSessionAsync` declaring success then immediately tripping on the next list call.
- Updated mocked tests for the new two-call shape; added the failure-mode test that mirrors the real bug (sync ok, list folders locked).

## Testing

- [x] Unit tests added/updated
- [x] Manual testing with PowerToys Command Palette
- [x] Existing tests pass (`dotnet test -p:Platform=x64`) — 491/492; one pre-existing failure (`RecordVerification_DoesNotPersistAcrossProcesses`) reads a real `%LocalAppData%` file from daily use, unrelated.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
- [x] Changed `.cs` files meet the 50% coverage threshold
- [ ] Wiki docs updated (no user-facing behavior change beyond the bug fix)