### PR TITLE
chore: 🙈 ignore C# Dev Kit .lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ obj/
 *.user
 *.suo
 *.cache
+*.lscache
 *.dll
 *.exe
 *.pdb


### PR DESCRIPTION
C# Dev Kit generates `*.lscache` language service caches next to `.csproj` files. They contain absolute paths and per-config build flags, and the file's own header notes they can be deleted and regenerated automatically.

The existing `*.cache` rule doesn't match `*.lscache` (different extension), so they were showing up as untracked.