### PR TITLE
fix: 🐛 gate vault unlock on bw status and distrust empty caches

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -55,6 +55,8 @@ public class BitwardenCliServiceMockedTests
     svc.SetSession("test-session-key");
     // IsCliAvailable
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
+    // VerifySessionAsync → status gate → "unlocked"
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"unlocked\"}\n", exitCode: 0));
     // VerifySessionAsync → sync → "Syncing complete."
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
     // VerifySessionAsync → list folders → empty JSON array proves decryption worked
@@ -64,15 +66,34 @@ public class BitwardenCliServiceMockedTests
   }
 
   [Fact]
-  public async Task GetVaultStatus_WithSession_VerifyFails_FallsToFetchStatus()
+  public async Task GetVaultStatus_WithSession_StatusGateLocked_FallsToFetchStatus()
   {
     var (svc, factory) = CreateService();
     svc.SetSession("bad-session");
     // IsCliAvailable
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
+    // VerifySessionAsync → status gate reports locked → short-circuit, no sync/list
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"locked\"}\n", exitCode: 0));
+    // FetchStatusAsync → RunCliAsync("status")
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"locked\"}\n", exitCode: 0));
+    var result = await svc.GetVaultStatusAsync();
+    Assert.Equal(VaultStatus.Locked, result);
+  }
+
+  [Fact]
+  public async Task GetVaultStatus_WithSession_StatusUnlockedButDecryptFails_FallsToFetchStatus()
+  {
+    // Stale-key case: status reports unlocked, but the key can't actually decrypt
+    // (e.g. after a server-side key rotation), so the list-folders confirmation fails.
+    var (svc, factory) = CreateService();
+    svc.SetSession("stale-session");
+    // IsCliAvailable
+    factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
+    // VerifySessionAsync → status gate passes
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"unlocked\"}\n", exitCode: 0));
     // VerifySessionAsync → sync succeeds (sync only needs auth, not unlock)
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
-    // VerifySessionAsync → list folders fails because session is dead → HandleInvalidSession + throw
+    // VerifySessionAsync → list folders fails because the key is stale → HandleInvalidSession + throw
     factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "Vault is locked.\n", exitCode: 1));
     // FetchStatusAsync → RunCliAsync("status")
     factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"locked\"}\n", exitCode: 0));
@@ -661,6 +682,7 @@ public class BitwardenCliServiceMockedTests
     var (svc, factory) = CreateService();
     svc.SetSession("test-key");
     factory.Enqueue(new FakeCliProcess(stdout: "2025.1.0\n", exitCode: 0));
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"status\":\"unlocked\"}\n", exitCode: 0));
     factory.Enqueue(new FakeCliProcess(stdout: "Syncing complete.\n", exitCode: 0));
     factory.Enqueue(new FakeCliProcess(stdout: "[]\n", exitCode: 0));
     await svc.GetVaultStatusAsync();

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -58,6 +58,12 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private StatusMessage? _lastBiometricStatus;
     private volatile bool _biometricClickFailed;
     private volatile bool _autoBiometricTriggered;
+    // Latches one authoritative re-check when an unlocked vault renders zero
+    // items with no active search (genuinely empty, or a session that went
+    // stale without erroring). Reset on every status change so a real status
+    // transition re-arms it; set once we've kicked off the re-verify so a
+    // genuinely-empty vault doesn't re-trigger on each rebuild.
+    private volatile bool _emptyVaultReverifyArmed = true;
 
     public HoobiBitwardenCommandPaletteExtensionPage(BitwardenCliService service, BitwardenSettingsManager? settings = null)
     {
@@ -121,9 +127,11 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                     switch (_service.LastStatus)
                     {
                         case VaultStatus.Unlocked when _service.IsCacheLoaded:
-                            DebugLogService.Log("Page", $"GetItems: unlocked + cache loaded, {Search(_currentSearchText).Count} items");
-                            _currentItems = BuildListItems(Search(_currentSearchText));
+                            var loadedResults = Search(_currentSearchText);
+                            DebugLogService.Log("Page", $"GetItems: unlocked + cache loaded, {loadedResults.Count} items");
+                            _currentItems = BuildListItems(loadedResults);
                             IsLoading = false;
+                            ReverifyIfSuspiciouslyEmpty(loadedResults.Count);
                             break;
                         case VaultStatus.Unlocked:
                             // Vault open but warmup is still loading the cache.
@@ -241,6 +249,35 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _initComplete = true;
         IsLoading = false;
         RaiseItemsChanged();
+        ReverifyIfSuspiciouslyEmpty(results.Count);
+    }
+
+    // An unlocked vault that lists zero items with no active search is suspicious:
+    // either genuinely empty, or a session that went stale without erroring (the
+    // "No items found" symptom). Re-check authoritatively, once, in the background.
+    // If it flips to Locked, StatusChanged rebuilds into the unlock prompt; if it
+    // confirms unlocked but still empty, the vault really is empty and we stop.
+    private void ReverifyIfSuspiciouslyEmpty(int resultCount)
+    {
+        if (resultCount > 0) { _emptyVaultReverifyArmed = true; return; }
+        if (!string.IsNullOrWhiteSpace(_currentSearchText)) return;
+        if (_handlingAction) return;
+        if (!_emptyVaultReverifyArmed) return;
+        _emptyVaultReverifyArmed = false;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var status = await _service.GetVaultStatusAsync().ConfigureAwait(false);
+                if (status == VaultStatus.Unlocked && _service.CacheCount == 0)
+                    await _service.RefreshCacheAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                DebugLogService.Log("Page", $"ReverifyIfSuspiciouslyEmpty failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        });
     }
 
     private void OnStatusChanged()
@@ -265,7 +302,10 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 _biometricClickFailed = false;
                 _autoBiometricTriggered = false;
                 HideBiometricStatus();
-                _currentItems = BuildListItems(Search(_currentSearchText));
+                _emptyVaultReverifyArmed = true;
+                var rebuiltResults = Search(_currentSearchText);
+                _currentItems = BuildListItems(rebuiltResults);
+                ReverifyIfSuspiciouslyEmpty(rebuiltResults.Count);
                 break;
             case VaultStatus.Unauthenticated:
                 _biometricClickFailed = false;

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -62,6 +62,8 @@ internal sealed partial class BitwardenCliService
 
   public bool IsCacheLoaded => _cacheLoaded;
 
+  internal int CacheCount { get { lock (_cacheLock) return _cache.Count; } }
+
   public VaultStatus? LastStatus => _lastStatus;
 
   internal static string? ServerUrl { get; private set; }
@@ -412,17 +414,31 @@ internal sealed partial class BitwardenCliService
   {
     try
     {
-      // bw sync only requires authentication, not an unlocked vault: a stale
-      // session key will still pull the encrypted blob just fine and print
-      // "Syncing complete.", so sync alone is a false-positive session check.
-      // Pair it with a decryption-requiring call to actually exercise the
-      // session key. bw list folders is the cheapest such call - tiny payload
-      // but it has to decrypt to render. If the session is dead, RunCliAsync
-      // sees "Vault is locked" in stderr, fires HandleInvalidSession (which
-      // clears _sessionKey), and throws - the catch below returns false.
+      // Authoritative, network-free gate first. `bw status` reflects the active
+      // BW_SESSION and reports "unlocked" only when the session key actually
+      // unlocks the local vault; a locked or expired session reports "locked"
+      // (or "unauthenticated"). Checking this up front means a dead session is
+      // rejected definitively instead of being inferred later from an empty or
+      // failed list - the exact case that surfaced to users as "No items found"
+      // against an apparently-unlocked vault.
+      DebugLogService.Log("Verify", "Running bw status to gate session");
+      var statusJson = await RunCliAsync("status");
+      var status = JsonNode.Parse(statusJson)?["status"]?.GetValue<string>();
+      if (!string.Equals(status, "unlocked", StringComparison.OrdinalIgnoreCase))
+      {
+        DebugLogService.Log("Verify", $"bw status reports '{status ?? "null"}', session not unlocked");
+        _sessionKey = null;
+        return false;
+      }
+
+      // status can still report "unlocked" for a session key left stale by a
+      // server-side key rotation, so confirm with a sync (refresh local data)
+      // plus a decryption-requiring list folders. If the key can't decrypt,
+      // RunCliAsync sees "Vault is locked" in stderr, fires HandleInvalidSession
+      // (which clears _sessionKey), and throws - the catch below returns false.
       DebugLogService.Log("Verify", "Running bw sync");
       await RunCliAsync("sync", CliTimeoutMs, "Syncing complete.");
-      DebugLogService.Log("Verify", "Running bw list folders to verify session");
+      DebugLogService.Log("Verify", "Running bw list folders to confirm decryption");
       await RunCliAsync("list folders");
       DebugLogService.Log("Verify", "Session verified successfully");
       return true;
@@ -1363,7 +1379,7 @@ internal sealed partial class BitwardenCliService
         try
         {
           await RefreshCacheAsync();
-          if (IsCacheLoaded)
+          if (IsCacheLoaded && CacheCount > 0)
           {
             SetStatus(VaultStatus.Unlocked);
             _ = Task.Run(async () =>
@@ -1375,6 +1391,14 @@ internal sealed partial class BitwardenCliService
             WarmupCompleted?.Invoke();
             return;
           }
+
+          // Loaded but empty: a stale session can return an empty `list` with no
+          // error (exit 0), which would render as "No items found" against an
+          // apparently-unlocked vault. Don't trust the fast path here - fall
+          // through to the authoritative status check below, which either
+          // confirms unlocked (and repopulates after its sync) or flips to
+          // Locked. A genuinely empty vault simply pays one slower launch.
+          DebugLogService.Log("Warmup", $"Fast restore cache empty/unloaded (loaded={IsCacheLoaded}, count={CacheCount}); verifying authoritatively");
         }
         catch (InvalidOperationException)
         {


### PR DESCRIPTION
## Summary

Fixes the recurring "No items found" state where the vault looks unlocked but the CLI session has gone stale, so the user has to manually sync, which then reveals the vault is locked and prompts for the master password.

## Changes

- `VerifySessionAsync` gates on `bw status` first (authoritative, network-free) before the sync + list-folders decryption confirmation, so a locked or expired session is rejected definitively instead of inferred from a later empty or failed list.
- Warmup fast-path now requires a non-empty cache; a loaded-but-empty result falls through to the authoritative status check, which either repopulates after its sync or flips the vault to Locked.
- The vault page re-verifies once, in the background, when an unlocked vault renders zero items with no active search, rather than showing "No items found" for a session that went stale without erroring.

## Testing

- [x] Unit tests added/updated (verify-sequence mocked tests updated; added gate-locked and stale-key cases)
- [ ] Manual testing with PowerToys Command Palette
- [x] Existing tests pass (`dotnet test -p:Platform=x64`): 492 pass. One pre-existing, environment-dependent failure (`RecordVerification_DoesNotPersistAcrossProcesses`) is unrelated to this change: it asserts no `grace.json` on disk, but a real one from prior usage sits in LocalAppData. Fails on `main` in the same environment.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build -c Release -p:Platform=x64`)
- [ ] Changed `.cs` files meet the 50% coverage threshold
- [ ] Wiki docs updated (no user-facing behaviour or settings change)