### PR TITLE
fix(ci): 🐛 adopt v2 Dependency-Track hierarchy for SBOM upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -529,11 +529,11 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
-      # Channel routing for the Backstage hierarchy in Dependency-Track:
+      # Channel routing for the Backstage hierarchy in Dependency-Track (v2):
       #   release event              -> channel=release,    mark-latest=true,  no prune
       #   release-please PR (prerelease tag is cut by pre-release job)
       #                              -> channel=prerelease, mark-latest=false, prune
-      #   push / dispatch / other PR -> channel=ci/<branch>,mark-latest=false, prune
+      #   push / dispatch / other PR -> channel=ci + sub-channel=<branch>, mark-latest=false, prune
       - name: Read version
         id: version
         shell: pwsh
@@ -555,6 +555,10 @@ jobs:
           $isRelease = $env:EVENT_NAME -eq 'release'
           $isPrerelease = $env:EVENT_NAME -eq 'pull_request' -and $env:HEAD_REF -eq 'release-please--branches--main'
 
+          # v2 Backstage hierarchy: feature/CI builds nest under a shared "ci"
+          # channel with the branch as the sub-channel (channel=ci, sub-channel=<branch>).
+          # release / prerelease sit directly under the component (no sub-channel).
+          $subChannel = ''
           if ($isRelease) {
             $channel = 'release'
             $projectVersion = $env:REF_NAME
@@ -570,25 +574,30 @@ jobs:
           else {
             $branchSource = if ($env:EVENT_NAME -eq 'pull_request') { $env:HEAD_REF } else { $env:REF_NAME }
             $sanitized = ($branchSource -replace '[^A-Za-z0-9._/-]', '-')
-            $channel = "ci/$sanitized"
+            $channel = 'ci'
+            $subChannel = $sanitized
             $projectVersion = $env:SHA
             $markLatest = 'false'
             $prune = 'true'
           }
 
           "channel=$channel"               | Out-File -Append $env:GITHUB_OUTPUT
+          "sub_channel=$subChannel"        | Out-File -Append $env:GITHUB_OUTPUT
           "project_version=$projectVersion"| Out-File -Append $env:GITHUB_OUTPUT
           "mark_latest=$markLatest"        | Out-File -Append $env:GITHUB_OUTPUT
           "prune=$prune"                   | Out-File -Append $env:GITHUB_OUTPUT
           Write-Host "Channel:        $channel"
+          Write-Host "SubChannel:     $subChannel"
           Write-Host "ProjectVersion: $projectVersion"
           Write-Host "MarkLatest:     $markLatest"
           Write-Host "Prune:          $prune"
 
       - name: Generate CycloneDX SBOM
-        uses: hoobio/pipeline-tools/pipeline/github/step/cyclonedx-sbom-dotnet@v1.6.0
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-cyclonedx-sbom@feat/sbom-clean-scoping
         with:
-          solution-path: ${{ env.SOLUTION_PATH }}
+          app-language: dotnet
+          app-manifest-path: ${{ env.SOLUTION_PATH }}
+          dotnet-spec-version: '1.6'
           output-path: ${{ env.BOM_FILE }}
 
       - name: Upload SBOM artifact
@@ -600,7 +609,7 @@ jobs:
 
       - name: Upload SBOM to Dependency-Track
         if: env.DT_HOST != '' && env.DT_API_KEY != ''
-        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@v1.6.0
+        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@feat/sbom-clean-scoping
         with:
           bom-path: ${{ env.BOM_FILE }}
           upload-artifact: 'false'
@@ -610,6 +619,7 @@ jobs:
           system: ${{ env.DT_SYSTEM }}
           component: ${{ env.DT_COMPONENT }}
           channel: ${{ steps.dt.outputs.channel }}
+          sub-channel: ${{ steps.dt.outputs.sub_channel }}
           project-version: ${{ steps.dt.outputs.project_version }}
           project-tags: channel=${{ steps.dt.outputs.channel }},repo=${{ github.repository }},commit=${{ github.sha }},run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           mark-latest: ${{ steps.dt.outputs.mark_latest }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -593,7 +593,7 @@ jobs:
           Write-Host "Prune:          $prune"
 
       - name: Generate CycloneDX SBOM
-        uses: hoobio/pipeline-tools/pipeline/github/step/build-cyclonedx-sbom@feat/sbom-clean-scoping
+        uses: hoobio/pipeline-tools/pipeline/github/step/build-cyclonedx-sbom@v2.3.1
         with:
           app-language: dotnet
           app-manifest-path: ${{ env.SOLUTION_PATH }}
@@ -609,7 +609,7 @@ jobs:
 
       - name: Upload SBOM to Dependency-Track
         if: env.DT_HOST != '' && env.DT_API_KEY != ''
-        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@feat/sbom-clean-scoping
+        uses: hoobio/pipeline-tools/pipeline/github/job/upload-sbom-to-dependency-track@v2.3.1
         with:
           bom-path: ${{ env.BOM_FILE }}
           upload-artifact: 'false'


### PR DESCRIPTION
## Summary

Fixes the SBOM job's Dependency-Track upload, which fails with `POST /api/v1/bom 404 "The parent component could not be found."`

Root cause: the DT upload sent `channel=ci/<branch>` (v1 flat), but pipeline-tools' v2 bootstrap expects `channel=ci` + `sub-channel=<branch>` and migrates legacy `ci/<X>` umbrellas away, so the BOM POST referenced a parent that no longer existed.

## Changes

- Resolve DT channel as `channel=ci` + `sub-channel=<branch>` for CI builds (release / prerelease stay top-level).
- Pass `sub-channel` to the upload action.
- Generate via `build-cyclonedx-sbom` (dotnet) on the new pipeline-tools line.

## Testing

- [ ] CI green (this PR validates the upload end-to-end against pipeline-tools `feat/sbom-clean-scoping`)

> pipeline-tools refs point at `feat/sbom-clean-scoping` for end-to-end testing; they get flipped to the released tag before merge.