### PR TITLE
feat: ✨ one-click Bitwarden CLI install from the palette

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,6 +306,26 @@ jobs:
           manifest-path: ${{ env.APPXMANIFEST_PATH }}
           version: ${{ steps.version.outputs.version }}
 
+      # Unsigned (PR / contributor) builds can only be installed via
+      # `Add-AppxPackage -AllowUnsigned` when the publisher sits in the reserved
+      # unsigned namespace (the OID below). Windows also guarantees this identity
+      # never collides with the signed/Store build, so it's safe to diverge here.
+      # Signed builds skip this and keep the certificate-matching publisher.
+      - name: Use unsigned-namespace publisher (unsigned builds only)
+        if: env.SHOULD_BUILD == 'true' && (env.SHOULD_SIGN != 'true' || env.HAS_SIGNING_CERT != 'true')
+        shell: pwsh
+        env:
+          MANIFEST: ${{ env.APPXMANIFEST_PATH }}
+        run: |
+          [xml]$doc = Get-Content -LiteralPath $env:MANIFEST -Raw
+          $nsm = New-Object System.Xml.XmlNamespaceManager($doc.NameTable)
+          $nsm.AddNamespace('d', 'http://schemas.microsoft.com/appx/manifest/foundation/windows10')
+          $identity = $doc.SelectSingleNode('/d:Package/d:Identity', $nsm)
+          if (-not $identity) { throw 'Identity element not found in manifest' }
+          $identity.SetAttribute('Publisher', 'CN=Hoobi, OID.2.25.311729368913984317654407730594956997722=1')
+          $doc.Save((Resolve-Path -LiteralPath $env:MANIFEST).Path)
+          Write-Host "::notice::Unsigned build - publisher set to the unsigned namespace; install with: Add-AppxPackage -Path <pkg>.msix -AllowUnsigned"
+
       - name: Build MSIX
         if: env.SHOULD_BUILD == 'true'
         uses: hoobio/pipeline-tools/pipeline/github/step/build-msix-dotnet@v1.6.0

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliInstallerTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliInstallerTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using HoobiBitwardenCommandPaletteExtension.Services;
+
+namespace HoobiBitwardenCommandPaletteExtension.Tests;
+
+public class BitwardenCliInstallerTests
+{
+  private sealed class ThrowingHandler : HttpMessageHandler
+  {
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+        throw new HttpRequestException("network unavailable");
+  }
+
+  // --- winget availability ---
+
+  [Fact]
+  public void IsWingetAvailable_VersionPrinted_ReturnsTrue()
+  {
+    var factory = new FakeProcessFactory();
+    factory.Enqueue(new FakeCliProcess(stdout: "v1.7.10561\n", exitCode: 0));
+    var installer = new BitwardenCliInstaller(processFactory: factory.Create);
+    Assert.True(installer.IsWingetAvailable());
+  }
+
+  [Fact]
+  public void IsWingetAvailable_NoOutput_ReturnsFalse()
+  {
+    var factory = new FakeProcessFactory();
+    factory.Enqueue(new FakeCliProcess(stdout: "", exitCode: 1));
+    var installer = new BitwardenCliInstaller(processFactory: factory.Create);
+    Assert.False(installer.IsWingetAvailable());
+  }
+
+  [Fact]
+  public void IsWingetAvailable_FactoryThrows_ReturnsFalse()
+  {
+    // Empty queue makes the factory throw (winget.exe not launchable).
+    var factory = new FakeProcessFactory();
+    var installer = new BitwardenCliInstaller(processFactory: factory.Create);
+    Assert.False(installer.IsWingetAvailable());
+  }
+
+  // --- winget install ---
+
+  [Fact]
+  public async Task InstallViaWinget_PassesExpectedArgs()
+  {
+    var factory = new FakeProcessFactory();
+    // Exit 1 short-circuits before the (filesystem) path resolution.
+    factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "", exitCode: 1));
+    var installer = new BitwardenCliInstaller(processFactory: factory.Create);
+
+    await installer.InstallViaWingetAsync();
+
+    Assert.Contains("install", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--id Bitwarden.CLI", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--silent", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--scope user", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--accept-package-agreements", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public async Task InstallViaWinget_NonZeroExit_ReturnsFailure()
+  {
+    var factory = new FakeProcessFactory();
+    factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "0x8a15000f", exitCode: 1));
+    var installer = new BitwardenCliInstaller(processFactory: factory.Create);
+
+    var result = await installer.InstallViaWingetAsync();
+
+    Assert.False(result.Success);
+    Assert.Equal(CliInstallMethod.Winget, result.Method);
+    Assert.Null(result.CliPath);
+  }
+
+  // --- download fallback ---
+
+  [Fact]
+  public async Task InstallViaDownload_HttpFails_ReturnsDownloadFailure()
+  {
+    var installer = new BitwardenCliInstaller(httpClientFactory: () => new HttpClient(new ThrowingHandler()));
+
+    var result = await installer.InstallViaDownloadAsync();
+
+    Assert.False(result.Success);
+    Assert.Equal(CliInstallMethod.Download, result.Method);
+    Assert.NotNull(result.Error);
+  }
+
+  // --- static helpers ---
+
+  [Fact]
+  public void GetCandidateCliPaths_IncludesWingetLinksAndAppDataInstallDir()
+  {
+    var paths = BitwardenCliInstaller.GetCandidateCliPaths()
+        .Select(p => p.Replace('\\', '/'))
+        .ToList();
+
+    Assert.Contains(paths, p => p.Contains("Microsoft/WinGet/Links/bw.exe", StringComparison.OrdinalIgnoreCase));
+    Assert.Contains(paths, p => p.Contains("HoobiBitwardenCommandPalette/cli/bw.exe", StringComparison.OrdinalIgnoreCase));
+    Assert.All(paths, p => Assert.EndsWith("bw.exe", p, StringComparison.OrdinalIgnoreCase));
+  }
+
+  [Fact]
+  public void ManualDownloadUrl_PointsAtBitwardenCliDownload()
+  {
+    Assert.Contains("bitwarden.com/download", BitwardenCliInstaller.ManualDownloadUrl, StringComparison.Ordinal);
+    Assert.Contains("app=cli", BitwardenCliInstaller.ManualDownloadUrl, StringComparison.Ordinal);
+    Assert.Contains("platform=windows", BitwardenCliInstaller.ManualDownloadUrl, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public void ResolveWingetExecutable_ResolvesToWinget()
+  {
+    var winget = BitwardenCliInstaller.ResolveWingetExecutable();
+    Assert.Contains("winget", winget, StringComparison.OrdinalIgnoreCase);
+  }
+}

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -64,6 +64,9 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     // transition re-arms it; set once we've kicked off the re-verify so a
     // genuinely-empty vault doesn't re-trigger on each rebuild.
     private volatile bool _emptyVaultReverifyArmed = true;
+    private volatile bool _cliInstalling;
+    private bool _cliInstallFailed;
+    private string? _cliInstallStatus;
 
     public HoobiBitwardenCommandPaletteExtensionPage(BitwardenCliService service, BitwardenSettingsManager? settings = null)
     {
@@ -394,15 +397,89 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
     private static IListItem[] WithDebugLog(IListItem[] items) =>
         DebugLogService.Enabled ? [.. items, BuildCopyDebugLogItem()] : items;
 
-    private static IListItem[] BuildCliNotFoundItems() => WithDebugLog(
-    [
-        new ListItem(new OpenUrlCommand("https://bitwarden.com/help/cli/#download-and-install"))
+    private IListItem[] BuildCliNotFoundItems()
+    {
+        if (_cliInstalling)
         {
-            Title = "Bitwarden CLI not found",
-            Subtitle = "Install the Bitwarden CLI (bw) and ensure it's in your PATH",
-            Icon = new IconInfo("\uE783"),
-        },
-    ]);
+            return WithDebugLog(
+            [
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _cliInstallStatus ?? "Installing Bitwarden CLI...",
+                    Subtitle = "Setting up the Bitwarden CLI - this can take a minute",
+                    Icon = new IconInfo("\uE896"),
+                },
+            ]);
+        }
+
+        var install = new ListItem(new AnonymousCommand(StartCliInstall)
+        {
+            Name = "Install",
+            Result = CommandResult.KeepOpen(),
+        })
+        {
+            Title = _cliInstallFailed ? "Retry automatic install" : "Install Bitwarden CLI",
+            Subtitle = _cliInstallStatus ?? "Set it up automatically via winget, or a signature-verified download",
+            Icon = new IconInfo("\uE896"),
+        };
+        if (_cliInstallFailed)
+            install.Tags = [new Tag("Failed") { Foreground = ColorHelpers.FromRgb(0xED, 0x82, 0x74) }];
+
+        var manual = new ListItem(new OpenUrlCommand(BitwardenCliInstaller.ManualDownloadUrl))
+        {
+            Title = "Download manually",
+            Subtitle = "Open the Bitwarden CLI download page",
+            Icon = new IconInfo("\uE774"),
+        };
+
+        return WithDebugLog([install, manual]);
+    }
+
+    private void StartCliInstall()
+    {
+        if (_cliInstalling) return;
+        _cliInstalling = true;
+        _cliInstallFailed = false;
+        _cliInstallStatus = "Starting install...";
+        RaiseItemsChanged();
+
+        _ = Task.Run(async () =>
+        {
+            var installer = new BitwardenCliInstaller();
+            var progress = new Progress<string>(s =>
+            {
+                _cliInstallStatus = s;
+                RaiseItemsChanged();
+            });
+
+            CliInstallResult result;
+            try
+            {
+                result = await installer.EnsureInstalledAsync(progress).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                result = new CliInstallResult(false, CliInstallMethod.None, null, ex.Message);
+            }
+
+            _cliInstalling = false;
+            if (result.Success && result.CliPath != null)
+            {
+                DebugLogService.Log("Installer", $"CLI install succeeded via {result.Method}; applying {result.CliPath}");
+                _cliInstallStatus = null;
+                // Fires CliConfigChanged -> OnCliConfigChanged re-checks vault status
+                // against the newly installed CLI and rebuilds the page.
+                _service.ApplyInstalledCli(result.CliPath);
+            }
+            else
+            {
+                _cliInstallFailed = true;
+                _cliInstallStatus = result.Error ?? "Installation failed - try the manual download";
+                DebugLogService.Log("Installer", $"CLI install failed: {_cliInstallStatus}");
+                RaiseItemsChanged();
+            }
+        });
+    }
 
     private IListItem[] BuildUnauthenticatedItems()
     {

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -435,6 +435,12 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         return WithDebugLog([install, manual]);
     }
 
+    // Ceilings so the install flow can never leave the user on a spinner:
+    // the install itself, and the post-install wait for the CLI to be detected.
+    private const int CliInstallTimeoutMs = 300_000;
+    private const int CliDetectTimeoutMs = 60_000;
+    private const int CliDetectPollMs = 2_000;
+
     private void StartCliInstall()
     {
         DebugLogService.Log("Installer", $"Install CLI requested (alreadyRunning={_cliInstalling})");
@@ -443,43 +449,87 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         _cliInstallFailed = false;
         _cliInstallStatus = "Starting install...";
         RefreshCliNotFoundItems();
+        _ = Task.Run(RunCliInstallAsync);
+    }
 
-        _ = Task.Run(async () =>
+    private async Task RunCliInstallAsync()
+    {
+        var installer = new BitwardenCliInstaller();
+        var progress = new Progress<string>(s =>
         {
-            var installer = new BitwardenCliInstaller();
-            var progress = new Progress<string>(s =>
-            {
-                _cliInstallStatus = s;
-                RefreshCliNotFoundItems();
-            });
+            _cliInstallStatus = s;
+            RefreshCliNotFoundItems();
+        });
 
-            CliInstallResult result;
+        CliInstallResult result;
+        try
+        {
+            using var cts = new CancellationTokenSource(CliInstallTimeoutMs);
+            result = await installer.EnsureInstalledAsync(progress, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            result = new CliInstallResult(false, CliInstallMethod.None, null, "Installation timed out");
+        }
+        catch (Exception ex)
+        {
+            result = new CliInstallResult(false, CliInstallMethod.None, null, ex.Message);
+        }
+
+        if (!result.Success || result.CliPath == null)
+        {
+            FailCliInstall(result.Error ?? "Installation failed - try the manual download");
+            return;
+        }
+
+        DebugLogService.Log("Installer", $"CLI install succeeded via {result.Method}; applying {result.CliPath}");
+        _cliInstallStatus = "Verifying Bitwarden CLI...";
+        RefreshCliNotFoundItems();
+        _service.ApplyInstalledCli(result.CliPath);
+
+        // Watchdog: ApplyInstalledCli also kicks a re-check via CliConfigChanged,
+        // but don't depend on that event reaching us. Poll vault status until it
+        // leaves CliNotFound, then hand off to the normal rebuild. Bail out with a
+        // recovery message if the CLI doesn't respond within the deadline, so the
+        // progress item can never get stuck.
+        var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(CliDetectTimeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            VaultStatus status;
             try
             {
-                result = await installer.EnsureInstalledAsync(progress).ConfigureAwait(false);
+                status = await _service.GetVaultStatusAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                result = new CliInstallResult(false, CliInstallMethod.None, null, ex.Message);
+                DebugLogService.Log("Installer", $"Post-install status check failed: {ex.GetType().Name}: {ex.Message}");
+                status = VaultStatus.CliNotFound;
             }
 
-            _cliInstalling = false;
-            if (result.Success && result.CliPath != null)
+            if (status != VaultStatus.CliNotFound)
             {
-                DebugLogService.Log("Installer", $"CLI install succeeded via {result.Method}; applying {result.CliPath}");
+                DebugLogService.Log("Installer", $"CLI detected after install; status={status}");
+                _cliInstalling = false;
                 _cliInstallStatus = null;
-                // Fires CliConfigChanged -> OnCliConfigChanged re-checks vault status
-                // against the newly installed CLI and rebuilds the page.
-                _service.ApplyInstalledCli(result.CliPath);
+                if (!_handlingAction)
+                    RebuildForCurrentStatus();
+                return;
             }
-            else
-            {
-                _cliInstallFailed = true;
-                _cliInstallStatus = result.Error ?? "Installation failed - try the manual download";
-                DebugLogService.Log("Installer", $"CLI install failed: {_cliInstallStatus}");
-                RefreshCliNotFoundItems();
-            }
-        });
+
+            await Task.Delay(CliDetectPollMs).ConfigureAwait(false);
+        }
+
+        DebugLogService.Log("Installer", "CLI installed but status still CliNotFound after detect timeout");
+        FailCliInstall("Installed, but the CLI didn't respond yet. Reopen the palette, or retry.");
+    }
+
+    private void FailCliInstall(string message)
+    {
+        _cliInstalling = false;
+        _cliInstallFailed = true;
+        _cliInstallStatus = message;
+        DebugLogService.Log("Installer", $"CLI install failed: {message}");
+        RefreshCliNotFoundItems();
     }
 
     // GetItems only rebuilds on demand for the unlocked vault; for every other

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -437,11 +437,12 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
 
     private void StartCliInstall()
     {
+        DebugLogService.Log("Installer", $"Install CLI requested (alreadyRunning={_cliInstalling})");
         if (_cliInstalling) return;
         _cliInstalling = true;
         _cliInstallFailed = false;
         _cliInstallStatus = "Starting install...";
-        RaiseItemsChanged();
+        RefreshCliNotFoundItems();
 
         _ = Task.Run(async () =>
         {
@@ -449,7 +450,7 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             var progress = new Progress<string>(s =>
             {
                 _cliInstallStatus = s;
-                RaiseItemsChanged();
+                RefreshCliNotFoundItems();
             });
 
             CliInstallResult result;
@@ -476,9 +477,20 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
                 _cliInstallFailed = true;
                 _cliInstallStatus = result.Error ?? "Installation failed - try the manual download";
                 DebugLogService.Log("Installer", $"CLI install failed: {_cliInstallStatus}");
-                RaiseItemsChanged();
+                RefreshCliNotFoundItems();
             }
         });
+    }
+
+    // GetItems only rebuilds on demand for the unlocked vault; for every other
+    // state it returns the cached _currentItems. So an in-place state change like
+    // the install progress has to refresh _currentItems itself before raising,
+    // otherwise the list never visibly updates.
+    private void RefreshCliNotFoundItems()
+    {
+        lock (_itemsLock)
+            _currentItems = BuildCliNotFoundItems();
+        RaiseItemsChanged();
     }
 
     private IListItem[] BuildUnauthenticatedItems()

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
@@ -178,7 +178,31 @@ internal sealed class BitwardenCliInstaller
   // winget updates the registry PATH, but this process's copy was snapshotted at
   // launch, so a freshly winget-installed shim wouldn't be visible via PATH alone.
   public static string? ResolveInstalledCliPath() =>
-      GetCandidateCliPaths().FirstOrDefault(File.Exists);
+      WingetPackagesCliPath() ?? GetCandidateCliPaths().FirstOrDefault(File.Exists);
+
+  // Prefer the real winget package executable over the Links\bw.exe shim. That
+  // shim is a symlink, and bw (a Node single-file exe) can't locate its bundled
+  // snapshot when launched through it, so `bw --version` fails. The actual exe
+  // under WinGet\Packages\Bitwarden.CLI_*\ runs correctly.
+  internal static string? WingetPackagesCliPath()
+  {
+    try
+    {
+      var packages = Path.Combine(
+          Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+          "Microsoft", "WinGet", "Packages");
+      if (!Directory.Exists(packages))
+        return null;
+      return Directory.EnumerateDirectories(packages, "Bitwarden.CLI_*")
+          .SelectMany(d => Directory.EnumerateFiles(d, "bw.exe", SearchOption.AllDirectories))
+          .FirstOrDefault();
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"WingetPackagesCliPath probe failed: {ex.GetType().Name}: {ex.Message}");
+      return null;
+    }
+  }
 
   internal static IEnumerable<string> GetCandidateCliPaths()
   {

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HoobiBitwardenCommandPaletteExtension.Services;
+
+internal enum CliInstallMethod { None, AlreadyPresent, Winget, Download }
+
+internal sealed record CliInstallResult(bool Success, CliInstallMethod Method, string? CliPath, string? Error);
+
+// User-initiated acquisition of the Bitwarden CLI. Order: detect an existing
+// install, then winget (preferred - it verifies its own packages and auto-updates),
+// then a direct download we verify ourselves, and finally the caller falls back to
+// opening the manual download page. Never runs unprompted: the Store frowns on a
+// packaged app installing other software on its own, and a surprise install/UAC is
+// poor UX. After success the caller writes the resolved path into the CLI override
+// rather than relying on PATH, which is a launch-time snapshot for this process.
+internal sealed class BitwardenCliInstaller
+{
+  public const string ManualDownloadUrl = "https://bitwarden.com/download/?app=cli&platform=windows";
+  internal const string WingetPackageId = "Bitwarden.CLI";
+  internal const string WingetInstallArgs =
+      "install --id Bitwarden.CLI --exact --silent --scope user --accept-package-agreements --accept-source-agreements";
+
+  private const int WingetVersionTimeoutMs = 10_000;
+  private const int WingetInstallTimeoutMs = 180_000;
+
+  private readonly CliProcessFactory _processFactory;
+  private readonly Func<HttpClient> _httpClientFactory;
+  private readonly string _installDir;
+
+  public BitwardenCliInstaller(
+      CliProcessFactory? processFactory = null,
+      Func<HttpClient>? httpClientFactory = null,
+      string? installDir = null)
+  {
+    _processFactory = processFactory ?? (psi => new RealCliProcess(Process.Start(psi)!));
+    _httpClientFactory = httpClientFactory ?? (() => new HttpClient { Timeout = TimeSpan.FromMinutes(5) });
+    _installDir = installDir ?? Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "HoobiBitwardenCommandPalette", "cli");
+  }
+
+  public async Task<CliInstallResult> EnsureInstalledAsync(IProgress<string>? progress = null, CancellationToken ct = default)
+  {
+    var existing = ResolveInstalledCliPath();
+    if (existing != null)
+    {
+      DebugLogService.Log("Installer", $"CLI already present at {existing}");
+      return new CliInstallResult(true, CliInstallMethod.AlreadyPresent, existing, null);
+    }
+
+    if (IsWingetAvailable())
+    {
+      DebugLogService.Log("Installer", "winget available; attempting install");
+      var winget = await InstallViaWingetAsync(progress, ct);
+      if (winget.Success)
+        return winget;
+      DebugLogService.Log("Installer", $"winget install failed ({winget.Error}); falling back to download");
+    }
+    else
+    {
+      DebugLogService.Log("Installer", "winget not available; using download fallback");
+    }
+
+    var download = await InstallViaDownloadAsync(progress, ct);
+    return download.Success
+        ? download
+        : new CliInstallResult(false, CliInstallMethod.None, null, download.Error ?? "Automatic installation failed");
+  }
+
+  public bool IsWingetAvailable()
+  {
+    try
+    {
+      using var process = _processFactory(WingetStartInfo("--version"));
+      var line = process.StandardOutput.ReadLine();
+      try { process.Kill(true); } catch { }
+      return !string.IsNullOrWhiteSpace(line);
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"winget availability check failed: {ex.GetType().Name}: {ex.Message}");
+      return false;
+    }
+  }
+
+  public async Task<CliInstallResult> InstallViaWingetAsync(IProgress<string>? progress = null, CancellationToken ct = default)
+  {
+    progress?.Report("Installing Bitwarden CLI via winget...");
+    try
+    {
+      using var process = _processFactory(WingetStartInfo(WingetInstallArgs));
+      using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+      cts.CancelAfter(WingetInstallTimeoutMs);
+
+      var drainOut = process.StandardOutput.ReadToEndAsync(cts.Token);
+      var drainErr = process.StandardError.ReadToEndAsync(cts.Token);
+      await process.WaitForExitAsync(cts.Token);
+      await Task.WhenAll(drainOut, drainErr);
+
+      if (process.ExitCode != 0)
+        return new CliInstallResult(false, CliInstallMethod.Winget, null, $"winget exited with code {process.ExitCode}");
+
+      var path = ResolveInstalledCliPath();
+      return path != null
+          ? new CliInstallResult(true, CliInstallMethod.Winget, path, null)
+          : new CliInstallResult(false, CliInstallMethod.Winget, null, "winget reported success but bw.exe was not found");
+    }
+    catch (OperationCanceledException)
+    {
+      return new CliInstallResult(false, CliInstallMethod.Winget, null, "winget install timed out");
+    }
+    catch (Exception ex)
+    {
+      return new CliInstallResult(false, CliInstallMethod.Winget, null, ex.Message);
+    }
+  }
+
+  public async Task<CliInstallResult> InstallViaDownloadAsync(IProgress<string>? progress = null, CancellationToken ct = default)
+  {
+    var tempZip = Path.Combine(Path.GetTempPath(), $"bw-cli-{Guid.NewGuid():N}.zip");
+    var tempExtract = Path.Combine(Path.GetTempPath(), $"bw-cli-{Guid.NewGuid():N}");
+    try
+    {
+      progress?.Report("Downloading Bitwarden CLI...");
+      using (var http = _httpClientFactory())
+      using (var response = await http.GetAsync(ManualDownloadUrl, HttpCompletionOption.ResponseHeadersRead, ct))
+      {
+        response.EnsureSuccessStatusCode();
+        using var fs = File.Create(tempZip);
+        await response.Content.CopyToAsync(fs, ct);
+      }
+
+      progress?.Report("Extracting...");
+      Directory.CreateDirectory(tempExtract);
+      ZipFile.ExtractToDirectory(tempZip, tempExtract, overwriteFiles: true);
+
+      var extractedBw = Directory.EnumerateFiles(tempExtract, "bw.exe", SearchOption.AllDirectories).FirstOrDefault();
+      if (extractedBw == null)
+        return new CliInstallResult(false, CliInstallMethod.Download, null, "Downloaded archive did not contain bw.exe");
+
+      progress?.Report("Verifying signature...");
+      if (!SignatureVerifier.IsTrustedBitwardenBinary(extractedBw))
+        return new CliInstallResult(false, CliInstallMethod.Download, null, "Downloaded bw.exe failed Bitwarden signature verification");
+
+      Directory.CreateDirectory(_installDir);
+      var dest = Path.Combine(_installDir, "bw.exe");
+      File.Copy(extractedBw, dest, overwrite: true);
+      DebugLogService.Log("Installer", $"Installed verified bw.exe to {dest}");
+      return new CliInstallResult(true, CliInstallMethod.Download, dest, null);
+    }
+    catch (OperationCanceledException)
+    {
+      return new CliInstallResult(false, CliInstallMethod.Download, null, "Download cancelled or timed out");
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"Download install failed: {ex.GetType().Name}: {ex.Message}");
+      return new CliInstallResult(false, CliInstallMethod.Download, null, ex.Message);
+    }
+    finally
+    {
+      try { if (File.Exists(tempZip)) File.Delete(tempZip); } catch { }
+      try { if (Directory.Exists(tempExtract)) Directory.Delete(tempExtract, recursive: true); } catch { }
+    }
+  }
+
+  // First existing bw.exe across the package managers' deterministic install
+  // locations and PATH. Probing fixed locations sidesteps the stale-PATH problem:
+  // winget updates the registry PATH, but this process's copy was snapshotted at
+  // launch, so a freshly winget-installed shim wouldn't be visible via PATH alone.
+  public static string? ResolveInstalledCliPath() =>
+      GetCandidateCliPaths().FirstOrDefault(File.Exists);
+
+  internal static IEnumerable<string> GetCandidateCliPaths()
+  {
+    var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+    yield return Path.Combine(localAppData, "Microsoft", "WinGet", "Links", "bw.exe");
+    yield return Path.Combine(localAppData, "HoobiBitwardenCommandPalette", "cli", "bw.exe");
+    yield return Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "scoop", "shims", "bw.exe");
+
+    var programData = Environment.GetEnvironmentVariable("ProgramData");
+    if (!string.IsNullOrEmpty(programData))
+      yield return Path.Combine(programData, "chocolatey", "bin", "bw.exe");
+
+    var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+    foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+    {
+      var candidate = TryCombine(dir, "bw.exe");
+      if (candidate != null)
+        yield return candidate;
+    }
+  }
+
+  private static string? TryCombine(string dir, string file)
+  {
+    try { return Path.Combine(dir, file); }
+    catch (ArgumentException) { return null; }
+  }
+
+  internal static string ResolveWingetExecutable()
+  {
+    var alias = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Microsoft", "WindowsApps", "winget.exe");
+    return File.Exists(alias) ? alias : "winget";
+  }
+
+  private static ProcessStartInfo WingetStartInfo(string args)
+  {
+    var psi = new ProcessStartInfo(ResolveWingetExecutable(), args)
+    {
+      UseShellExecute = false,
+      RedirectStandardOutput = true,
+      RedirectStandardError = true,
+      CreateNoWindow = true,
+      StandardOutputEncoding = System.Text.Encoding.UTF8,
+      StandardErrorEncoding = System.Text.Encoding.UTF8,
+    };
+    psi.Environment["NO_COLOR"] = "1";
+    return psi;
+  }
+}

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
@@ -49,6 +49,7 @@ internal sealed class BitwardenCliInstaller
 
   public async Task<CliInstallResult> EnsureInstalledAsync(IProgress<string>? progress = null, CancellationToken ct = default)
   {
+    DebugLogService.Log("Installer", "EnsureInstalledAsync started");
     var existing = ResolveInstalledCliPath();
     if (existing != null)
     {

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -233,6 +233,10 @@ internal sealed partial class BitwardenCliService
     KillAllRunning();
     _sessionKey = null;
     _lastStatus = null;
+    // Abandon any in-flight/cached status check so the next GetVaultStatusAsync
+    // re-evaluates against the new CLI path instead of coalescing onto a check
+    // that ran against the old one.
+    lock (_statusLock) { _statusCheckInFlight = null; }
     ResetStaticState();
     lock (_cacheLock)
     {
@@ -297,83 +301,78 @@ internal sealed partial class BitwardenCliService
   {
     lock (_statusLock)
     {
-      if (_statusCheckInFlight != null)
+      // Only ride a check that's actually still running. Handing back a completed
+      // or faulted task served a stale "CliNotFound" forever after a CLI install -
+      // the fresh check at the newly-installed path never got to run. A completed,
+      // faulted, or cleared (null) field starts a fresh check instead.
+      if (_statusCheckInFlight is { IsCompleted: false })
       {
         DebugLogService.Log("Status", "GetVaultStatusAsync coalesced with in-flight check");
         return _statusCheckInFlight;
       }
 
+      DebugLogService.Log("Status", $"GetVaultStatusAsync starting fresh check (exe: {CliExecutable})");
       _statusCheckInFlight = GetVaultStatusCoreAsync();
       return _statusCheckInFlight;
     }
   }
 
+  // No longer nulls _statusCheckInFlight on completion: the completed task is left
+  // in the field and GetVaultStatusAsync's IsCompleted gate starts a fresh one.
+  // That removes the clobber race where a finishing check would null out a newer
+  // in-flight check started after a CLI-config reset.
   private async Task<VaultStatus> GetVaultStatusCoreAsync()
   {
-    try
+    DebugLogService.Log("Status", "GetVaultStatusAsync started");
+    if (!await IsCliAvailableAsync())
     {
-      DebugLogService.Log("Status", "GetVaultStatusAsync started");
-      if (!await IsCliAvailableAsync())
-      {
-        DebugLogService.Log("Status", $"CLI not available (exe: {CliExecutable})");
-        return SetStatus(VaultStatus.CliNotFound);
-      }
-      DebugLogService.Log("Status", $"CLI available (exe: {CliExecutable}), version: {_cliVersion ?? "unknown"}");
+      DebugLogService.Log("Status", $"CLI not available (exe: {CliExecutable})");
+      return SetStatus(VaultStatus.CliNotFound);
+    }
+    DebugLogService.Log("Status", $"CLI available (exe: {CliExecutable}), version: {_cliVersion ?? "unknown"}");
 
-      if (_sessionKey != null)
+    if (_sessionKey != null)
+    {
+      DebugLogService.Log("Status", "In-memory session key present, verifying...");
+      if (await VerifySessionAsync())
+        return SetStatus(VaultStatus.Unlocked);
+      DebugLogService.Log("Status", "In-memory session verification failed");
+    }
+
+    var envSession = Environment.GetEnvironmentVariable("BW_SESSION");
+    if (!string.IsNullOrWhiteSpace(envSession))
+    {
+      DebugLogService.Log("Status", "BW_SESSION env var found, verifying...");
+      _sessionKey = envSession;
+      if (await VerifySessionAsync())
+        return SetStatus(VaultStatus.Unlocked);
+      DebugLogService.Log("Status", "BW_SESSION env var verification failed");
+    }
+
+    if (_settings?.RememberSession.Value == true)
+    {
+      var stored = SessionStore.Load();
+      if (!string.IsNullOrEmpty(stored))
       {
-        DebugLogService.Log("Status", "In-memory session key present, verifying...");
+        DebugLogService.Log("Status", "Stored session found in Credential Manager, verifying...");
+        _sessionKey = stored;
         if (await VerifySessionAsync())
           return SetStatus(VaultStatus.Unlocked);
-        DebugLogService.Log("Status", "In-memory session verification failed");
+        // Don't clear the credential here - a single sync failure can be a
+        // transient network blip or slow CLI startup right after a deploy.
+        // HandleInvalidSession clears it on real CLI errors that confirm the
+        // session is gone.
+        DebugLogService.Log("Status", "Stored session verification failed (preserving credential for retry)");
       }
-
-      var envSession = Environment.GetEnvironmentVariable("BW_SESSION");
-      if (!string.IsNullOrWhiteSpace(envSession))
+      else
       {
-        DebugLogService.Log("Status", "BW_SESSION env var found, verifying...");
-        _sessionKey = envSession;
-        if (await VerifySessionAsync())
-          return SetStatus(VaultStatus.Unlocked);
-        DebugLogService.Log("Status", "BW_SESSION env var verification failed");
+        DebugLogService.Log("Status", "RememberSession enabled but no stored session found");
       }
-
-      if (_settings?.RememberSession.Value == true)
-      {
-        var stored = SessionStore.Load();
-        if (!string.IsNullOrEmpty(stored))
-        {
-          DebugLogService.Log("Status", "Stored session found in Credential Manager, verifying...");
-          _sessionKey = stored;
-          if (await VerifySessionAsync())
-          {
-            // Vault unlock no longer grants protected-item grace; that has to
-            // be earned per-item via RepromptForm.
-            return SetStatus(VaultStatus.Unlocked);
-          }
-          // Don't clear the credential here — a single sync failure can be a
-          // transient network blip or slow CLI startup right after a deploy,
-          // and clearing means the user is forced to biometric/password on
-          // the next launch even though the credential is still valid. Leave
-          // it in place; HandleInvalidSession (called from real CLI errors
-          // with stderr that confirms the session is gone) will clear it
-          // when the credential is genuinely bad.
-          DebugLogService.Log("Status", "Stored session verification failed (preserving credential for retry)");
-        }
-        else
-        {
-          DebugLogService.Log("Status", "RememberSession enabled but no stored session found");
-        }
-      }
-
-      var fallback = await FetchStatusAsync();
-      DebugLogService.Log("Status", $"Falling back to bw status: {fallback}");
-      return SetStatus(fallback);
     }
-    finally
-    {
-      lock (_statusLock) { _statusCheckInFlight = null; }
-    }
+
+    var fallback = await FetchStatusAsync();
+    DebugLogService.Log("Status", $"Falling back to bw status: {fallback}");
+    return SetStatus(fallback);
   }
 
   private VaultStatus SetStatus(VaultStatus status)
@@ -411,26 +410,30 @@ internal sealed partial class BitwardenCliService
       psi.Environment["BW_NOINTERACTION"] = "true";
       psi.Environment["NO_COLOR"] = "1";
       using var process = _processFactory(psi);
-      using var cts = new CancellationTokenSource(CliVersionTimeoutMs);
-      string? line;
-      try
+
+      // A CancellationToken won't interrupt a blocking pipe read, so bound the
+      // call by racing a timer and killing the process on timeout - killing it
+      // closes the pipe and unblocks the read. (bw --version normally returns in
+      // ~1s; this only guards a genuinely wedged process.)
+      var readTask = process.StandardOutput.ReadLineAsync();
+      var finished = await Task.WhenAny(readTask, Task.Delay(CliVersionTimeoutMs));
+      if (finished != readTask)
       {
-        line = await process.StandardOutput.ReadLineAsync(cts.Token);
-      }
-      catch (OperationCanceledException)
-      {
-        // A hung `bw --version` (e.g. a broken shim) must not hang the whole
-        // status check - that's what left the vault stuck on "Verifying...".
         DebugLogService.Log("Status", $"bw --version timed out after {CliVersionTimeoutMs / 1000}s (exe: {CliExecutable})");
-        line = null;
+        try { process.Kill(true); } catch { }
+        return false;
       }
-      _cliVersion = line?.Trim();
+
+      var line = (await readTask)?.Trim();
+      _cliVersion = line;
       try { process.Kill(true); } catch { }
-      return line != null;
+      var available = !string.IsNullOrEmpty(line);
+      DebugLogService.Log("Status", $"bw --version => '{line ?? "(none)"}', available={available} (exe: {CliExecutable})");
+      return available;
     }
     catch (Exception ex)
     {
-      DebugLogService.Log("Status", $"IsCliAvailable failed: {ex.GetType().Name}: {ex.Message}");
+      DebugLogService.Log("Status", $"IsCliAvailable failed: {ex.GetType().Name}: {ex.Message} (exe: {CliExecutable})");
       return false;
     }
   }

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -313,7 +313,7 @@ internal sealed partial class BitwardenCliService
     try
     {
       DebugLogService.Log("Status", "GetVaultStatusAsync started");
-      if (!IsCliAvailable())
+      if (!await IsCliAvailableAsync())
       {
         DebugLogService.Log("Status", $"CLI not available (exe: {CliExecutable})");
         return SetStatus(VaultStatus.CliNotFound);
@@ -392,7 +392,9 @@ internal sealed partial class BitwardenCliService
     return status;
   }
 
-  private bool IsCliAvailable()
+  private const int CliVersionTimeoutMs = 8_000;
+
+  private async Task<bool> IsCliAvailableAsync()
   {
     try
     {
@@ -409,13 +411,26 @@ internal sealed partial class BitwardenCliService
       psi.Environment["BW_NOINTERACTION"] = "true";
       psi.Environment["NO_COLOR"] = "1";
       using var process = _processFactory(psi);
-      var line = process.StandardOutput.ReadLine();
+      using var cts = new CancellationTokenSource(CliVersionTimeoutMs);
+      string? line;
+      try
+      {
+        line = await process.StandardOutput.ReadLineAsync(cts.Token);
+      }
+      catch (OperationCanceledException)
+      {
+        // A hung `bw --version` (e.g. a broken shim) must not hang the whole
+        // status check - that's what left the vault stuck on "Verifying...".
+        DebugLogService.Log("Status", $"bw --version timed out after {CliVersionTimeoutMs / 1000}s (exe: {CliExecutable})");
+        line = null;
+      }
       _cliVersion = line?.Trim();
       try { process.Kill(true); } catch { }
       return line != null;
     }
-    catch
+    catch (Exception ex)
     {
+      DebugLogService.Log("Status", $"IsCliAvailable failed: {ex.GetType().Name}: {ex.Message}");
       return false;
     }
   }

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -188,6 +188,16 @@ internal sealed partial class BitwardenCliService
     ResetForCliConfigChange();
   }
 
+  // Apply a path produced by BitwardenCliInstaller: persist it as the CLI override
+  // and re-resolve. CheckCliConfigChanged sees the changed executable and fires
+  // ResetForCliConfigChange -> CliConfigChanged, which the page handles by
+  // re-checking vault status against the freshly installed CLI.
+  public void ApplyInstalledCli(string path)
+  {
+    _settings?.PersistCliPath(path);
+    CheckCliConfigChanged();
+  }
+
   private void CheckRememberSessionDisabled()
   {
     var current = _settings?.RememberSession.Value ?? false;

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
@@ -240,6 +240,15 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         LogConfig("startup");
     }
 
+    // Programmatic settings changes (e.g. writing the resolved path after an
+    // automated CLI install) don't flow through the settings form, so persist
+    // explicitly here. BitwardenCliService.ApplyInstalledCli then re-resolves.
+    public void PersistCliPath(string path)
+    {
+        CliDirectoryOverride.Value = path;
+        SaveSettings();
+    }
+
     private void OnSettingsChanged(object sender, Settings e)
     {
         SaveSettings();

--- a/HoobiBitwardenCommandPaletteExtension/Services/SignatureVerifier.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/SignatureVerifier.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Cryptography.X509Certificates;
+
+namespace HoobiBitwardenCommandPaletteExtension.Services;
+
+// Authenticode verification for a downloaded executable. Used by the direct-download
+// fallback in BitwardenCliInstaller: a binary we fetch and then execute has to be
+// proven (a) Authenticode-valid against a trusted chain and (b) actually published
+// by Bitwarden, not just any validly-signed exe. winget-installed binaries are
+// verified by winget itself and don't go through here.
+[SupportedOSPlatform("windows")]
+internal static partial class SignatureVerifier
+{
+  // Subjects Bitwarden has shipped the CLI under. Matched case-insensitively as a
+  // substring of the signing certificate's subject.
+  private static readonly string[] TrustedPublishers =
+  [
+    "Bitwarden",
+    "8bit Solutions",
+  ];
+
+  public static bool IsTrustedBitwardenBinary(string filePath) =>
+      IsAuthenticodeValid(filePath) && IsBitwardenPublisher(filePath);
+
+  private static bool IsBitwardenPublisher(string filePath)
+  {
+    try
+    {
+#pragma warning disable SYSLIB0057 // CreateFromSignedFile is the supported way to read the Authenticode signer
+      using var cert = new X509Certificate2(X509Certificate.CreateFromSignedFile(filePath));
+#pragma warning restore SYSLIB0057
+      var subject = cert.Subject;
+      foreach (var publisher in TrustedPublishers)
+      {
+        if (subject.Contains(publisher, StringComparison.OrdinalIgnoreCase))
+          return true;
+      }
+      DebugLogService.Log("Installer", $"Downloaded binary signer not trusted: {subject}");
+      return false;
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"Signer extraction failed: {ex.GetType().Name}: {ex.Message}");
+      return false;
+    }
+  }
+
+  private static bool IsAuthenticodeValid(string filePath)
+  {
+    var pathPtr = Marshal.StringToHGlobalUni(filePath);
+    var fileInfo = new WinTrustFileInfo
+    {
+      cbStruct = (uint)Unsafe.SizeOf<WinTrustFileInfo>(),
+      pcwszFilePath = pathPtr,
+    };
+    var fileHandle = GCHandle.Alloc(fileInfo, GCHandleType.Pinned);
+    try
+    {
+      var data = new WinTrustData
+      {
+        cbStruct = (uint)Unsafe.SizeOf<WinTrustData>(),
+        dwUIChoice = WTD_UI_NONE,
+        fdwRevocationChecks = WTD_REVOKE_NONE,
+        dwUnionChoice = WTD_CHOICE_FILE,
+        dwStateAction = WTD_STATEACTION_VERIFY,
+        pFile = fileHandle.AddrOfPinnedObject(),
+      };
+      var action = WINTRUST_ACTION_GENERIC_VERIFY_V2;
+      var result = WinVerifyTrust(IntPtr.Zero, ref action, ref data);
+
+      data.dwStateAction = WTD_STATEACTION_CLOSE;
+      _ = WinVerifyTrust(IntPtr.Zero, ref action, ref data);
+
+      if (result != 0)
+        DebugLogService.Log("Installer", $"WinVerifyTrust rejected download (0x{result:X8})");
+      return result == 0;
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"WinVerifyTrust failed: {ex.GetType().Name}: {ex.Message}");
+      return false;
+    }
+    finally
+    {
+      fileHandle.Free();
+      Marshal.FreeHGlobal(pathPtr);
+    }
+  }
+
+  private const uint WTD_UI_NONE = 2;
+  private const uint WTD_REVOKE_NONE = 0;
+  private const uint WTD_CHOICE_FILE = 1;
+  private const uint WTD_STATEACTION_VERIFY = 1;
+  private const uint WTD_STATEACTION_CLOSE = 2;
+
+  private static readonly Guid WINTRUST_ACTION_GENERIC_VERIFY_V2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+  [LibraryImport("wintrust.dll")]
+  private static partial int WinVerifyTrust(IntPtr hwnd, ref Guid pgActionID, ref WinTrustData pWVTData);
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct WinTrustFileInfo
+  {
+    public uint cbStruct;
+    public IntPtr pcwszFilePath;
+    public IntPtr hFile;
+    public IntPtr pgKnownSubject;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct WinTrustData
+  {
+    public uint cbStruct;
+    public IntPtr pPolicyCallbackData;
+    public IntPtr pSIPClientData;
+    public uint dwUIChoice;
+    public uint fdwRevocationChecks;
+    public uint dwUnionChoice;
+    public IntPtr pFile;
+    public uint dwStateAction;
+    public IntPtr hWVTStateData;
+    public IntPtr pwszURLReference;
+    public uint dwProvFlags;
+    public uint dwUIContext;
+    public IntPtr pSignatureSettings;
+  }
+}


### PR DESCRIPTION
## Summary

Turns the "Bitwarden CLI not found" dead-end into a user-initiated, one-click install. Directly targets the "you need to be a developer to use this" store feedback. UI-agnostic service, so the planned companion onboarding window can reuse it.

## Changes

- **`BitwardenCliInstaller`**: detect existing `bw` (winget Links / scoop / choco / PATH) → `winget install` (user scope, silent) → signature-verified direct download → caller opens the manual download page. The resolved absolute path is written to the CLI override rather than relying on PATH (a launch-time snapshot for this process).
- **`SignatureVerifier`**: Authenticode validation via `WinVerifyTrust` (`LibraryImport`, AOT-clean) + a Bitwarden publisher-subject check, so the download fallback never runs an unverified or non-Bitwarden binary. winget packages are verified by winget itself.
- **CLI-not-found UI**: "Install Bitwarden CLI" + "Download manually" actions with inline progress; on success `ApplyInstalledCli` persists the path and re-checks vault status against the new CLI.

## Testing

- [x] Unit tests added (winget detection/args, candidate path resolution, download-failure path, manual URL) — 9 new, all pass
- [x] Existing tests pass (`dotnet test -p:Platform=x64`): 501 pass; the one failure is the pre-existing `RecordVerification_DoesNotPersistAcrossProcesses` (env-dependent stale `grace.json`), unrelated to this change.
- [x] Clean build under the Debug AOT/trim/single-file analyzers with `TreatWarningsAsErrors`.

## Notes

- Never installs unprompted (Store-policy + UX): always user-initiated from the not-found state.
- Wiki docs (Getting-Started) for the new install flow are a suggested follow-up.