### PR TITLE
feat: ✨ side-by-side dev/prerelease/release package identities

### DIFF
--- a/.github/coverage-exclusions.json
+++ b/.github/coverage-exclusions.json
@@ -8,6 +8,10 @@
     "reason": "Entry point, WinRT activation boilerplate"
   },
   {
+    "pattern": "HoobiBitwardenCommandPaletteExtension\\.cs$",
+    "reason": "IExtension COM server class, WinRT activation boilerplate, cannot be instantiated in unit tests"
+  },
+  {
     "pattern": "CommandsProvider\\.cs$",
     "reason": "Bootstraps WinRT SDK types (CommandItem, CommandProvider) in constructor, cannot be instantiated in unit tests"
   },

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -273,6 +273,11 @@ jobs:
       # Sign on release-please PRs and on main pushes; PRs from contributors stay unsigned.
       SHOULD_SIGN: ${{ (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       HAS_SIGNING_CERT: ${{ secrets.SIGNING_CERTIFICATE != '' && vars.SIGNING_CERT_THUMBPRINT != '' }}
+      # Side-by-side package identity. The release-please pre-release PR builds the Prerelease
+      # channel (its own Identity Name, DisplayName, and COM CLSID); every other shipped build
+      # is Release. MSBuild promotes this env var to the $(PackageChannel) property the .csproj
+      # reads. Local Debug builds default to the Dev channel.
+      PackageChannel: ${{ (github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main') && 'Prerelease' || 'Release' }}
     steps:
       - name: Skip notice (no code changes)
         if: env.SHOULD_BUILD != 'true'

--- a/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.cs
+++ b/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.cs
@@ -9,7 +9,16 @@ using Microsoft.CommandPalette.Extensions;
 
 namespace HoobiBitwardenCommandPaletteExtension;
 
+// COM activation CLSID, one per side-by-side channel so Dev/Prerelease/Release can run
+// concurrently without fighting over the same class id. Must match the CLSID stamped into
+// Package.appxmanifest by the build (driven by PackageChannel in the .csproj).
+#if CHANNEL_DEV
+[Guid("ef6edc31-9567-4d38-8463-4a59b038148d")]
+#elif CHANNEL_PRERELEASE
+[Guid("e874e604-b64e-42f1-b391-756d4d406c51")]
+#else
 [Guid("8345c10d-0df8-4116-a767-3f8647adf4df")]
+#endif
 public sealed partial class HoobiBitwardenCommandPaletteExtension : IExtension, IDisposable
 {
     private readonly ManualResetEvent _extensionDisposedEvent;

--- a/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.csproj
+++ b/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtension.csproj
@@ -95,23 +95,50 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
-
-    <!-- Add .Debug suffix to package name for side-by-side installation -->
-    <PackageNameSuffix>.Debug</PackageNameSuffix>
-    <DisplayNameSuffix> (Dev)</DisplayNameSuffix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'!='Debug'">
-    <!-- In Release builds, trimming is enabled by default. 
+    <!-- In Release builds, trimming is enabled by default.
          feel free to disable this if needed -->
     <PublishTrimmed>true</PublishTrimmed>
 
     <!-- In release, also ignore the aforementioned ILLink warning -->
     <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
+  </PropertyGroup>
 
-    <!-- No suffix for release builds -->
+  <!--
+    Side-by-side channel identity. PackageChannel (Dev | Prerelease | Release) selects a
+    distinct package Identity Name, DisplayName, and COM activation CLSID so all three
+    channels install and run alongside each other (Add/Remove Programs, Command Palette,
+    COM activation). It defaults to Dev for local Debug builds and Release otherwise; CI
+    sets the PackageChannel env var to Prerelease for the release-please pre-release build.
+    The CLSID per channel must stay in lockstep with the [Guid] attribute selected in
+    HoobiBitwardenCommandPaletteExtension.cs (see CHANNEL_* DefineConstants below).
+  -->
+  <PropertyGroup>
+    <PackageChannel Condition="'$(PackageChannel)'=='' and '$(Configuration)'=='Debug'">Dev</PackageChannel>
+    <PackageChannel Condition="'$(PackageChannel)'==''">Release</PackageChannel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PackageChannel)'=='Dev'">
+    <PackageNameSuffix>.Dev</PackageNameSuffix>
+    <DisplayNameSuffix> (Dev)</DisplayNameSuffix>
+    <ComServerClsid>ef6edc31-9567-4d38-8463-4a59b038148d</ComServerClsid>
+    <DefineConstants>$(DefineConstants);CHANNEL_DEV</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PackageChannel)'=='Prerelease'">
+    <PackageNameSuffix>.Prerelease</PackageNameSuffix>
+    <DisplayNameSuffix> (Prerelease)</DisplayNameSuffix>
+    <ComServerClsid>e874e604-b64e-42f1-b391-756d4d406c51</ComServerClsid>
+    <DefineConstants>$(DefineConstants);CHANNEL_PRERELEASE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PackageChannel)'=='Release'">
     <PackageNameSuffix></PackageNameSuffix>
     <DisplayNameSuffix></DisplayNameSuffix>
+    <ComServerClsid>8345c10d-0df8-4116-a767-3f8647adf4df</ComServerClsid>
+    <DefineConstants>$(DefineConstants);CHANNEL_RELEASE</DefineConstants>
   </PropertyGroup>
 
   <Target Name="StampPackageIdentityName" BeforeTargets="Build;_ConvertItems">
@@ -167,6 +194,20 @@
     <XmlPoke XmlInputPath="$(AppxManifestPath)"
              Query="/ns:Package/ns:Applications/ns:Application/ns:Extensions/uap3:Extension/uap3:AppExtension/@Description"
              Value="$(FullDisplayName)"
+             Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/appx/manifest/foundation/windows10'/&gt;&lt;Namespace Prefix='uap3' Uri='http://schemas.microsoft.com/appx/manifest/uap/windows10/3'/&gt;" />
+    <!-- Stamp the per-channel COM activation CLSID. The Command Palette host activates the
+         extension by this class id; each channel needs its own so two channels don't claim
+         the same CLSID and collide. Must match the [Guid] in HoobiBitwardenCommandPaletteExtension.cs. -->
+    <Message Text="Stamping COM server CLSID: $(ComServerClsid)" Importance="high" Condition="'$(ComServerClsid)' != ''" />
+    <XmlPoke XmlInputPath="$(AppxManifestPath)"
+             Condition="'$(ComServerClsid)' != ''"
+             Query="/ns:Package/ns:Applications/ns:Application/ns:Extensions/com:Extension/com:ComServer/com:ExeServer/com:Class/@Id"
+             Value="$(ComServerClsid)"
+             Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/appx/manifest/foundation/windows10'/&gt;&lt;Namespace Prefix='com' Uri='http://schemas.microsoft.com/appx/manifest/com/windows10'/&gt;" />
+    <XmlPoke XmlInputPath="$(AppxManifestPath)"
+             Condition="'$(ComServerClsid)' != ''"
+             Query="/ns:Package/ns:Applications/ns:Application/ns:Extensions/uap3:Extension/uap3:AppExtension/uap3:Properties/ns:CmdPalProvider/ns:Activation/ns:CreateInstance/@ClassId"
+             Value="$(ComServerClsid)"
              Namespaces="&lt;Namespace Prefix='ns' Uri='http://schemas.microsoft.com/appx/manifest/foundation/windows10'/&gt;&lt;Namespace Prefix='uap3' Uri='http://schemas.microsoft.com/appx/manifest/uap/windows10/3'/&gt;" />
   </Target>
 

--- a/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
+++ b/HoobiBitwardenCommandPaletteExtension/Package.appxmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap uap3 rescap">
-  <Identity Name="Hoobi.BitwardenCommandPaletteExtension.Debug" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.9.2.0" />
+  <Identity Name="Hoobi.BitwardenCommandPaletteExtension" Publisher="CN=D74C026B-1081-4787-BDE6-0CFA2F1EDD71" Version="1.10.0.0" />
   <Properties>
-    <DisplayName>Command Palette Extension for Bitwarden (Dev)</DisplayName>
+    <DisplayName>Command Palette Extension for Bitwarden</DisplayName>
     <PublisherDisplayName>Hoobi</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -15,20 +15,20 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="Command Palette Extension for Bitwarden (Dev)" Description="Command Palette Extension for Bitwarden (Dev)" BackgroundColor="transparent" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png">
+      <uap:VisualElements DisplayName="Command Palette Extension for Bitwarden" Description="Command Palette Extension for Bitwarden" BackgroundColor="transparent" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
-            <com:ExeServer Executable="HoobiBitwardenCommandPaletteExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Command Palette Extension for Bitwarden (Dev)">
-              <com:Class Id="8345c10d-0df8-4116-a767-3f8647adf4df" DisplayName="Command Palette Extension for Bitwarden (Dev)" />
+            <com:ExeServer Executable="HoobiBitwardenCommandPaletteExtension.exe" Arguments="-RegisterProcessAsComServer" DisplayName="Command Palette Extension for Bitwarden">
+              <com:Class Id="8345c10d-0df8-4116-a767-3f8647adf4df" DisplayName="Command Palette Extension for Bitwarden" />
             </com:ExeServer>
           </com:ComServer>
         </com:Extension>
         <uap3:Extension Category="windows.appExtension">
-          <uap3:AppExtension Name="com.microsoft.commandpalette" Id="ID" PublicFolder="Public" DisplayName="Command Palette Extension for Bitwarden (Dev)" Description="Command Palette Extension for Bitwarden (Dev)">
+          <uap3:AppExtension Name="com.microsoft.commandpalette" Id="ID" PublicFolder="Public" DisplayName="Command Palette Extension for Bitwarden" Description="Command Palette Extension for Bitwarden">
             <uap3:Properties>
               <CmdPalProvider>
                 <Activation>


### PR DESCRIPTION
`PackageChannel` (Dev | Prerelease | Release) now drives a distinct package Identity Name, DisplayName, and COM activation CLSID per channel, so a dev build, a prerelease, and the Store/release install can sit side-by-side (Add/Remove Programs, Command Palette, and COM activation no longer collide on a shared CLSID).

- **Dev** (`.Dev` / "(Dev)") and **Prerelease** (`.Prerelease` / "(Prerelease)") each get their own identity and CLSID.
- **Release** identity and CLSID are unchanged, so Store updates aren't affected.

Defaults to Dev for local Debug builds and Release otherwise; the build workflow sets `PackageChannel=Prerelease` for the release-please pre-release build. The per-channel CLSID is stamped into the manifest and matched by an `#if`-selected `[Guid]` on the extension class.

Verified locally for all three channels (identity + CLSID switch correctly). The Prerelease path only runs in CI on a real release-please PR, so that leg is unverified until the next pre-release.
