### PR TITLE
fix: 🐛 re-enable email 2FA and surface unsupported-server 422 (#157)

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -247,17 +247,44 @@ public class BitwardenCliServiceMockedTests
     Assert.Contains("--code", factory.LastPsi!.Arguments, StringComparison.Ordinal);
   }
 
-  [Fact]
-  public async Task Login_MethodWithoutCode_OmitsMethodFlag()
+  [Theory]
+  [InlineData(0)]   // Authenticator/TOTP
+  [InlineData(3)]   // YubiKey OTP
+  public async Task Login_NonEmailMethodWithoutCode_OmitsMethodFlag(int method)
   {
-    // We deliberately do NOT pass --method on the first login attempt (no code),
-    // because that would make bw call postTwoFactorEmail for Email 2FA, which
-    // vaultwarden rejects with 422 (missing deviceIdentifier).
+    // For non-Email methods we don't pass --method on the first attempt (no code):
+    // a self-hosted server picking the wrong default would reject a valid code (#139/#158).
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "Two-step login is required.\n", exitCode: 1));
+    await svc.LoginAsync("user@test.com", "pass", twoFactorCode: null, twoFactorMethod: method);
+    Assert.DoesNotContain("--method", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.DoesNotContain("--code", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public async Task Login_EmailMethodWithoutCode_PassesMethodToTriggerSend()
+  {
+    // Email is the exception: the CLI only emails a code when --method 1 is passed
+    // (it calls send-email-login), so we trigger it on the first attempt (#157).
     var (svc, factory) = CreateService();
     factory.Enqueue(new FakeCliProcess(stdout: "", stderr: "Two-step login is required.\n", exitCode: 1));
     await svc.LoginAsync("user@test.com", "pass", twoFactorCode: null, twoFactorMethod: 1);
-    Assert.DoesNotContain("--method", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+    Assert.Contains("--method 1", factory.LastPsi!.Arguments, StringComparison.Ordinal);
     Assert.DoesNotContain("--code", factory.LastPsi!.Arguments, StringComparison.Ordinal);
+  }
+
+  [Fact]
+  public async Task Login_EmailMethod_ServerRejectsWith422_ReturnsUseAnotherMethodError()
+  {
+    // vaultwarden without the #7225 fix 422s send-email-login. Rather than prompt
+    // for a code that never arrives, surface a clear "use another method" error.
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "{\"response\":null,\"statusCode\":422}\n", stderr: "", exitCode: 1));
+    var (success, error, twoFa, deviceVerification) = await svc.LoginAsync("user@test.com", "pass", twoFactorCode: null, twoFactorMethod: 1);
+    Assert.False(success);
+    Assert.False(twoFa);
+    Assert.False(deviceVerification);
+    Assert.Contains("Email 2FA isn't supported", error!, StringComparison.Ordinal);
   }
 
   [Fact]

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -1306,7 +1306,10 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
             try
             {
                 ShowLoadingStatus("Logging in...", "bw login");
-                var (success, error, twoFactorRequired, deviceVerificationRequired) = await _service.LoginAsync(email, password, null);
+                // Pass the chosen method on the first attempt so Email (1) triggers the
+                // CLI's send-email-login call. Non-Email methods stay method-less here
+                // (see LoginAsync); the method is also kept for the second (code) attempt.
+                var (success, error, twoFactorRequired, deviceVerificationRequired) = await _service.LoginAsync(email, password, null, twoFactorMethod);
                 if (!success)
                 {
                     if (twoFactorRequired)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -84,13 +84,14 @@ internal sealed partial class LoginForm : FormContent
                 "style": "compact",
                 "choices": [
                     { "title": "Authenticator app", "value": "0" },
+                    { "title": "Email", "value": "1" },
                     { "title": "YubiKey OTP", "value": "3" },
                     { "title": "Auto-detect", "value": "{{NoMethodValue}}" }
                 ]
             },
             {
                 "type": "TextBlock",
-                "text": "Email 2FA isn't supported ([#157](https://github.com/hoobio/command-palette-bitwarden/issues/157)). For Duo Push or WebAuthn, run `bw login` in a terminal first, then unlock here with your master password.",
+                "text": "For Duo Push or WebAuthn, run `bw login` in a terminal first, then unlock here with your master password.",
                 "wrap": true,
                 "isSubtle": true,
                 "size": "small"

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -729,6 +729,9 @@ internal sealed partial class BitwardenCliService
     }
   }
 
+  // Bitwarden TwoFactorProviderType value for Email 2FA (see two-factor-provider-type.ts).
+  internal const int EmailTwoFactorMethod = 1;
+
   // Default twoFactorMethod is 0 (Authenticator/TOTP). Self-hosted servers can
   // otherwise return a different default (e.g. email) when --method is omitted,
   // causing valid TOTP codes to be rejected as invalid (issue #139). Pass an
@@ -741,19 +744,25 @@ internal sealed partial class BitwardenCliService
     {
       var sanitizedEmail = email.Replace("\"", "");
       var args = $"login \"{sanitizedEmail}\" --passwordenv BW_MP";
-      // Only pass --method alongside --code on the second attempt. Tempting as it
-      // is to send --method on the first attempt too (so the CLI picks the right
-      // provider straight away and triggers Email 2FA's postTwoFactorEmail call),
-      // vaultwarden < 1.36 (and master at the time of writing) rejects
-      // postTwoFactorEmail with 422 because its SendEmailLoginData struct
-      // mandates deviceIdentifier, which the bw CLI doesn't include in the body.
-      // See vaultwarden src/api/core/two_factor/email.rs and issue #139 thread.
+      // For non-Email methods we don't pass --method on the first attempt (no code):
+      // letting the CLI report the required provider avoids a self-hosted server
+      // picking the wrong default and rejecting a valid TOTP code (issue #139/#158).
+      // Email is the exception: the CLI only emails a code when it calls
+      // send-email-login, which it does only when --method 1 is supplied. So Email
+      // gets the flag on the first attempt to actually trigger the send. On servers
+      // missing the vaultwarden #7225 fix this 422s (SendEmailLoginData mandates a
+      // deviceIdentifier the CLI never sends); we detect that below and surface a
+      // "use another method" error instead of a dead-end code prompt (issue #157).
       if (!string.IsNullOrEmpty(twoFactorCode))
       {
         var sanitizedCode = twoFactorCode.Replace("\"", "");
         args += twoFactorMethod.HasValue
             ? $" --method {twoFactorMethod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)} --code \"{sanitizedCode}\""
             : $" --code \"{sanitizedCode}\"";
+      }
+      else if (twoFactorMethod == EmailTwoFactorMethod)
+      {
+        args += $" --method {EmailTwoFactorMethod.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
       }
       args += " --raw";
 
@@ -833,6 +842,21 @@ internal sealed partial class BitwardenCliService
         if (_settings?.RememberSession.Value == true)
           SessionStore.Save(stdout);
         return (true, null, false, false);
+      }
+
+      // Email 2FA send rejected by the server. vaultwarden before the #7225 fix
+      // 422s send-email-login (its SendEmailLoginData mandates a deviceIdentifier
+      // the bw CLI doesn't send), so the code is never emailed. Surface an
+      // actionable message instead of prompting for a code that will never arrive.
+      var combined = stdout + "\n" + stderr;
+      if (twoFactorMethod == EmailTwoFactorMethod && string.IsNullOrEmpty(twoFactorCode)
+          && combined.Contains("422", StringComparison.Ordinal)
+          && combined.Contains("statusCode", StringComparison.OrdinalIgnoreCase))
+      {
+        DebugLogService.Log("Auth", "Email 2FA send rejected with 422 - server lacks the send-email-login fix (#157)");
+        return (false,
+            "Email 2FA isn't supported by this server yet (requires new Vaultwarden release #157).",
+            false, false);
       }
 
       var needs2fa = stderr.Contains("Two-step", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Email 2FA is selectable again. The `bw` CLI only sends the email code when `--method 1` is passed (it calls `send-email-login`), so the extension now triggers that on the first login attempt when Email is chosen. Other methods stay method-less on the first attempt (per #139/#158).

Servers missing the vaultwarden fix (PR #7225, not in a release as of 1.36.0) reject `send-email-login` with **422**. We detect that and surface a clear "pick a different method (Authenticator or YubiKey), or run `bw login` in a terminal" message instead of prompting for a code that never arrives. On a fixed server the code sends and login proceeds normally.

Mitigation for #157, not a close: Email still needs a vaultwarden release carrying #7225 (the fix is merged to `main` but unreleased). Tests cover the trigger, the non-Email method-less path, and the 422 detection.
