### PR TITLE
feat: ✨ submit auth forms with Enter via keyboard hook + UIA shim

### DIFF
--- a/.github/coverage-exclusions.json
+++ b/.github/coverage-exclusions.json
@@ -30,5 +30,9 @@
   {
     "pattern": "ICliProcess\\.cs$",
     "reason": "Interface + thin RealCliProcess wrapper delegating to System.Diagnostics.Process, no testable logic"
+  },
+  {
+    "pattern": "EnterKeySubmitService\\.cs$",
+    "reason": "Win32 low-level keyboard hook + UI Automation COM interop against the live Command Palette host window, cannot be exercised in unit tests"
   }
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,51 @@
-# GitHub Copilot Instructions
+# Agent Instructions
+
+Guidance for AI coding agents (Copilot, Claude Code, etc.) working in this repository.
+
+## Local Build & Deploy
+
+This is an out-of-process Command Palette extension (a packaged WinRT COM server). To see a code change live you must rebuild, re-register the package, and restart PowerToys.
+
+VS Code task **Build, Kill & Deploy (Debug x64)** (`.vscode/tasks.json`) runs the full cycle: kill PowerToys, build, register the loose package, restart PowerToys. The equivalent commands:
+
+```powershell
+# 1. Stop PowerToys, Command Palette, and the extension host so files unlock
+@('PowerToys','Microsoft.CmdPal.UI','HoobiBitwardenCommandPaletteExtension') +
+  ((Get-Process | Where-Object ProcessName -like 'Microsoft.CmdPal.Ext.*').ProcessName | Select-Object -Unique) |
+  Select-Object -Unique | ForEach-Object { Get-Process $_ -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue }
+
+# 2. Build (Debug stamps the side-by-side "Dev" channel identity)
+dotnet build .\HoobiBitwardenCommandPaletteExtension\HoobiBitwardenCommandPaletteExtension.csproj -c Debug /p:Platform=x64
+
+# 3. Register the loose layout, then restart PowerToys
+$out = '.\HoobiBitwardenCommandPaletteExtension\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64'
+Copy-Item "$out\..\..\..\..\..\Assets\*" "$out\Assets" -Recurse -Force
+Add-AppxPackage -Register -Path "$out\AppxManifest.xml" -ForceUpdateFromAnyVersion
+Start-Process 'shell:AppsFolder\Microsoft.PowerToysWin32'
+```
+
+Debug builds install as a separate **Dev** channel (`Hoobi.BitwardenCommandPaletteExtension.Dev`, display name suffixed `(Dev)`) so they sit side by side with a production install. Test against the **(Dev)** entry in Command Palette.
+
+### Working in a git worktree (important)
+
+`Add-AppxPackage -Register` deduplicates on package **identity + version**. The Dev identity and version (`1.10.0.0`) are the same across every checkout, so if a Dev package is already registered (e.g. pointing at the main checkout's `bin`), registering again from a worktree's `bin` is silently skipped (`Deployed.` prints, but `InstallLocation` does not change). You then run old code and think the change "did nothing".
+
+When deploying from a worktree, force the registration to repoint:
+
+```powershell
+# Confirm where the Dev package currently points
+(Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev').InstallLocation
+
+# If it isn't your worktree bin: remove it, then re-register from the worktree
+Remove-AppxPackage -Package (Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev').PackageFullName
+Add-AppxPackage -Register -Path "<worktree>\HoobiBitwardenCommandPaletteExtension\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64\AppxManifest.xml" -ForceUpdateFromAnyVersion
+```
+
+Stamping note: a Debug build rewrites `Package.appxmanifest` to the Dev identity as a side effect. Don't commit that change. If the generated output `AppxManifest.xml` ever goes stale (shows the Release identity), delete `bin\...\win-x64\AppxManifest.xml` and `bin\...\win-x64\AppX` and rebuild to regenerate it.
 
 ## Git Commit Message Format
 
-All commit messages MUST follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for release-please compatibility.
-Commits and pull requests in this repo DO NOT require an Azure DevOps work item number as this repo is not associated with an Azure DevOps project.
+All commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/) for release-please compatibility. Commits and PRs in this repo do NOT require an Azure DevOps work item number (this repo isn't associated with an ADO project).
 
 ### Required Format
 
@@ -87,14 +129,12 @@ feat(utils): another feature in the same PR
 - Only `feat`, `fix`, `perf`, and `revert` types produce changelog entries; `ci`, `test`, `docs`, `chore` do not
 - These additional entries each produce their own changelog line
 
-## Notes
+### Notes
 
 - First line limited to 72 characters
 - Description uses imperative mood ("add" not "adds" or "added")
 - No period at end of description
 - Emoji are NOT allowed (incompatible with release-please)
-
----
 
 ## Command Palette Extension SDK Reference
 
@@ -122,7 +162,7 @@ When you need to look up SDK types, interfaces, properties, or capabilities, use
 - **IDL (full API surface):** https://raw.githubusercontent.com/microsoft/PowerToys/main/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
 - **Toolkit C# wrappers:** https://github.com/microsoft/PowerToys/tree/main/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit
 - Key files: `ListItem.cs`, `Tag.cs`, `DynamicListPage.cs`, `ColorHelpers.cs`, `StatusMessage.cs`, `CommandResult.cs`
-- Use `fetch_webpage` to read raw source files directly from GitHub
+- Read raw source files directly from GitHub
 
 ### 5. Inspecting NuGet DLLs (last resort)
 
@@ -142,25 +182,19 @@ When you need to look up SDK types, interfaces, properties, or capabilities, use
 - `StatusMessage` - Status bar message with `MessageState` (`Info`, `Success`, `Warning`, `Error`)
 - `IconInfo` - Icon from Segoe MDL2 Assets unicode or image URL
 
----
-
 ## PowerShell Terminal Commands
 
 - In PowerShell, the escape character is a backtick (`` ` ``), **not** a backslash (`\`)
 - When constructing multi-line strings or escaping quotes in terminal commands, use `` `" `` not `\"`
 - Example: `gh pr create --body "line one`nline two"` not `"line one\nline two"`
 
----
-
 ## Code Coverage
 
 Every C# source file touched in a PR must meet **50% line coverage** (measured against unit tests in `HoobiBitwardenCommandPaletteExtension.Tests`). The CI pipeline enforces this and will fail the PR if the threshold is not met.
 
 - When adding or modifying logic in a `.cs` file, add or update tests in the corresponding test file under `HoobiBitwardenCommandPaletteExtension.Tests/`
-- Files listed in `.github/coverage-exclusions.json` are exempt from the threshold (e.g. UI-only pages that can't be unit tested)
+- Files listed in `.github/coverage-exclusions.json` are exempt from the threshold (e.g. UI-only pages, Win32/COM interop that can't be unit tested)
 - Test files themselves (`*.Tests/**`) are excluded from coverage measurement
-
----
 
 ## Wiki Documentation (`docs/`)
 
@@ -168,8 +202,8 @@ The `docs/` folder contains GitHub Wiki pages documenting all extension function
 
 ### When to Update
 
-- **Adding a feature**: Add relevant details to the appropriate wiki page, or create a new page if the feature is significant. Update [Home.md](../docs/Home.md) and [\_Sidebar.md](../docs/_Sidebar.md) if adding a new page.
+- **Adding a feature**: Add relevant details to the appropriate wiki page, or create a new page if the feature is significant. Update [Home.md](docs/Home.md) and [\_Sidebar.md](docs/_Sidebar.md) if adding a new page.
 - **Changing behavior**: Update the page that describes the affected feature.
-- **Adding/changing settings**: Update [Settings.md](../docs/Settings.md) with the new setting's type, default, and description.
-- **Changing sort order or tags**: Update [Search-and-Filtering.md](../docs/Search-and-Filtering.md) and/or [Watchtower-Tags.md](../docs/Watchtower-Tags.md).
-- **Changing architecture/services**: Update [Architecture.md](../docs/Architecture.md).
+- **Adding/changing settings**: Update [Settings.md](docs/Settings.md) with the new setting's type, default, and description.
+- **Changing sort order or tags**: Update [Search-and-Filtering.md](docs/Search-and-Filtering.md) and/or [Watchtower-Tags.md](docs/Watchtower-Tags.md).
+- **Changing architecture/services**: Update [Architecture.md](docs/Architecture.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
@@ -410,11 +410,16 @@ public class VaultItemHelperTests
     RepromptPage.GracePeriodSeconds = 60;
     RepromptPage.ClearGracePeriod();
 
-    RepromptPage.RecordVerification("item-a");
-
+    // Start from a clean slate: a stale grace.json from an older build (which
+    // did persist) must not make this regression test pass or fail spuriously.
     var graceFile = Path.Combine(
       Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
       "HoobiBitwardenCommandPalette", "grace.json");
+    if (File.Exists(graceFile))
+      File.Delete(graceFile);
+
+    RepromptPage.RecordVerification("item-a");
+
     Assert.False(File.Exists(graceFile));
     RepromptPage.ClearGracePeriod();
   }

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -18,11 +18,17 @@ internal sealed partial class LoginPage : ContentPage
     _form = new LoginForm(service, settings, onSubmit);
   }
 
-  public override IContent[] GetContent() => [_form];
+  public override IContent[] GetContent()
+  {
+    EnterKeySubmitService.Arm(LoginForm.SubmitButtonTitle);
+    return [_form];
+  }
 }
 
 internal sealed partial class LoginForm : FormContent
 {
+  internal const string SubmitButtonTitle = "Login";
+
   // Sentinel value in the ChoiceSet for "don't pass --method to bw login".
   // Numeric values match Bitwarden's TwoFactorProviderType enum
   // (libs/common/src/auth/enums/two-factor-provider-type.ts in bitwarden/clients).
@@ -101,7 +107,7 @@ internal sealed partial class LoginForm : FormContent
                 "actions": [
                     {
                         "type": "Action.Submit",
-                        "title": "Login"
+                        "title": "{{SubmitButtonTitle}}"
                     }
                 ]
             },
@@ -112,13 +118,6 @@ internal sealed partial class LoginForm : FormContent
                 "valueOn": "true",
                 "valueOff": "false",
                 "value": "{{(rememberChecked ? "true" : "false")}}"
-            },
-            {
-                "type": "TextBlock",
-                "text": "[Upvote this issue](https://github.com/microsoft/PowerToys/issues/46003) to help bring Enter key support.",
-                "wrap": true,
-                "isSubtle": true,
-                "size": "small"
             }
         ]
     }
@@ -135,6 +134,7 @@ internal sealed partial class LoginForm : FormContent
 
   public override ICommandResult SubmitForm(string inputs, string data)
   {
+    EnterKeySubmitService.Disarm();
     var formInput = JsonNode.Parse(inputs)?.AsObject();
     var email = formInput?["Email"]?.GetValue<string>()?.Trim();
     var password = formInput?["MasterPassword"]?.GetValue<string>();

--- a/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/LoginPage.cs
@@ -134,13 +134,16 @@ internal sealed partial class LoginForm : FormContent
 
   public override ICommandResult SubmitForm(string inputs, string data)
   {
-    EnterKeySubmitService.Disarm();
     var formInput = JsonNode.Parse(inputs)?.AsObject();
     var email = formInput?["Email"]?.GetValue<string>()?.Trim();
     var password = formInput?["MasterPassword"]?.GetValue<string>();
 
+    // Keep the form armed on an empty submit (KeepOpen leaves it open), else a
+    // single Enter on an empty field would disable Enter for the form's life.
     if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
       return CommandResult.KeepOpen();
+
+    EnterKeySubmitService.Disarm();
 
     var remember = formInput?["RememberSession"]?.GetValue<string>() == "true";
     if (_settings != null && _settings.RememberSession.Value != remember)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/RepromptPage.cs
@@ -82,11 +82,17 @@ internal sealed partial class RepromptPage : ContentPage
     _form = new RepromptForm(service, itemId, innerAction, actionLabel);
   }
 
-  public override IContent[] GetContent() => [_form];
+  public override IContent[] GetContent()
+  {
+    EnterKeySubmitService.Arm(RepromptForm.SubmitButtonTitle);
+    return [_form];
+  }
 }
 
 internal sealed partial class RepromptForm : FormContent
 {
+  internal const string SubmitButtonTitle = "Verify & Continue";
+
   private readonly BitwardenCliService _service;
   private readonly string _itemId;
   private readonly Action _innerAction;
@@ -220,6 +226,7 @@ internal sealed partial class RepromptForm : FormContent
   // time it has already been treated as cancelled).
   private CommandResult HandleBiometric()
   {
+    EnterKeySubmitService.Disarm();
     RepromptPage.RaiseBiometricRequested(
       new BiometricVerificationRequest(_itemId, _service, _innerAction, _actionLabel));
     return CommandResult.GoBack();
@@ -266,6 +273,7 @@ internal sealed partial class RepromptForm : FormContent
       return CommandResult.KeepOpen();
     }
 
+    EnterKeySubmitService.Disarm();
     RepromptPage.RecordVerification(_itemId);
     try { _innerAction(); }
     catch (Exception ex)

--- a/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
@@ -18,11 +18,17 @@ internal sealed partial class UnlockVaultPage : ContentPage
     _form = new UnlockForm(service, settings, onSubmit, onBiometricUnlock);
   }
 
-  public override IContent[] GetContent() => [_form];
+  public override IContent[] GetContent()
+  {
+    EnterKeySubmitService.Arm(UnlockForm.SubmitButtonTitle);
+    return [_form];
+  }
 }
 
 internal sealed partial class UnlockForm : FormContent
 {
+  internal const string SubmitButtonTitle = "Unlock";
+
   private readonly BitwardenCliService _service;
   private readonly BitwardenSettingsManager? _settings;
   private readonly Action<string>? _onSubmit;
@@ -69,7 +75,7 @@ internal sealed partial class UnlockForm : FormContent
                 "actions": [
                     {
                         "type": "Action.Submit",
-                        "title": "Unlock",
+                        "title": "{{SubmitButtonTitle}}",
                         "data": { "action": "password" }
                     }{{windowsHelloAction}}
                 ]
@@ -81,13 +87,6 @@ internal sealed partial class UnlockForm : FormContent
                 "valueOn": "true",
                 "valueOff": "false",
                 "value": "{{(rememberChecked ? "true" : "false")}}"
-            },
-            {
-                "type": "TextBlock",
-                "text": "[Upvote this issue](https://github.com/microsoft/PowerToys/issues/46003) to help bring Enter key support.",
-                "wrap": true,
-                "isSubtle": true,
-                "size": "small"
             }
         ]
     }
@@ -105,6 +104,7 @@ internal sealed partial class UnlockForm : FormContent
 
   public override ICommandResult SubmitForm(string inputs, string data)
   {
+    EnterKeySubmitService.Disarm();
     var formInput = JsonNode.Parse(inputs)?.AsObject();
     var actionData = JsonNode.Parse(data)?.AsObject();
     var action = actionData?["action"]?.GetValue<string>();

--- a/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/UnlockVaultPage.cs
@@ -104,7 +104,6 @@ internal sealed partial class UnlockForm : FormContent
 
   public override ICommandResult SubmitForm(string inputs, string data)
   {
-    EnterKeySubmitService.Disarm();
     var formInput = JsonNode.Parse(inputs)?.AsObject();
     var actionData = JsonNode.Parse(data)?.AsObject();
     var action = actionData?["action"]?.GetValue<string>();
@@ -118,16 +117,21 @@ internal sealed partial class UnlockForm : FormContent
 
     if (action == "biometric")
     {
+      EnterKeySubmitService.Disarm();
       _onBiometricUnlock?.Invoke();
       // Same behavior as the password path: the unlock runs asynchronously
       // on the parent page (status + items refresh), so the form is done.
       return CommandResult.GoBack();
     }
 
+    // Keep the form armed on an empty submit (form stays open via KeepOpen),
+    // otherwise pressing Enter once with an empty field would disable Enter
+    // for the rest of the form's life. Disarm only when we navigate away.
     var password = formInput?["MasterPassword"]?.GetValue<string>();
     if (string.IsNullOrEmpty(password))
       return CommandResult.KeepOpen();
 
+    EnterKeySubmitService.Disarm();
     _onSubmit?.Invoke(password);
     return CommandResult.GoBack();
   }

--- a/HoobiBitwardenCommandPaletteExtension/Services/EnterKeySubmitService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/EnterKeySubmitService.cs
@@ -24,6 +24,14 @@ namespace HoobiBitwardenCommandPaletteExtension.Services;
 //
 // Known limitation: if PowerToys runs elevated and this extension does not, UIPI blocks
 // both the hook and UIA access, and Enter falls back to doing nothing (upstream status quo).
+//
+// Failsafe layering, so a global keyboard hook can never outlive a live form:
+//   1. The OS uninstalls the hook automatically if this process dies.
+//   2. The EVENT_SYSTEM_FOREGROUND WinEvent removes it the instant focus leaves
+//      Command Palette (covers the palette closing or being killed).
+//   3. A watchdog timer is the backstop for (2): out-of-context WinEvents can be
+//      dropped under load, so every tick it removes the hook if it's still
+//      installed while Command Palette is no longer the foreground window.
 internal static unsafe partial class EnterKeySubmitService
 {
   // Tests toggle this off so page GetContent calls don't install a real hook.
@@ -39,6 +47,8 @@ internal static unsafe partial class EnterKeySubmitService
   private static bool _pumpStarted;
   private static long _lastInvokeTimestamp;
   private static readonly ConcurrentDictionary<uint, bool> _pidIsCmdPal = new();
+  private static Timer? _watchdog;
+  private const int WatchdogIntervalMs = 2000;
 
   internal static void Arm(string submitButtonName)
   {
@@ -78,6 +88,26 @@ internal static unsafe partial class EnterKeySubmitService
       thread.Start();
       _pumpReady.Wait(TimeSpan.FromSeconds(5));
       _pumpStarted = true;
+      _watchdog ??= new Timer(static _ => WatchdogTick(), null, WatchdogIntervalMs, WatchdogIntervalMs);
+    }
+  }
+
+  // Backstop for a dropped foreground WinEvent (see class header): if the hook is
+  // still installed but Command Palette isn't foreground anymore, tear it down.
+  private static void WatchdogTick()
+  {
+    try
+    {
+      if (_keyboardHook == 0 || IsCommandPaletteWindow(GetForegroundWindow()))
+        return;
+
+      _armedButtonName = null;
+      if (_pumpStarted)
+        PostThreadMessageW(_pumpThreadId, WM_APP_UNINSTALL_HOOK, 0, 0);
+    }
+    catch
+    {
+      // Backstop must never throw on a timer thread.
     }
   }
 

--- a/HoobiBitwardenCommandPaletteExtension/Services/EnterKeySubmitService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/EnterKeySubmitService.cs
@@ -1,0 +1,465 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace HoobiBitwardenCommandPaletteExtension.Services;
+
+// Workaround for https://github.com/microsoft/PowerToys/issues/46003: the Command
+// Palette host doesn't wire Enter to Action.Submit in rendered Adaptive Card forms.
+// The extension runs out-of-process, so we can't touch the host's UI thread. Instead,
+// while one of our forms is armed, a low-level keyboard hook watches for Enter; when
+// pressed with a password box focused inside the Command Palette window, the form's
+// submit button is invoked through UI Automation, which drives the host's normal
+// SubmitForm pipeline.
+//
+// Privacy/safety constraints baked into the design:
+// - The hook callback inspects the virtual-key code only, acts only on VK_RETURN, and
+//   never records or forwards key data.
+// - The hook is installed only while one of our forms armed it, and is removed as soon
+//   as Command Palette loses foreground.
+// - The UIA invoke only fires when the focused element is a password field belonging
+//   to the Command Palette process, so a stale armed state cannot click anything else.
+//
+// Known limitation: if PowerToys runs elevated and this extension does not, UIPI blocks
+// both the hook and UIA access, and Enter falls back to doing nothing (upstream status quo).
+internal static unsafe partial class EnterKeySubmitService
+{
+  // Tests toggle this off so page GetContent calls don't install a real hook.
+  internal static bool HookingEnabled { get; set; } = true;
+
+  internal static string? ArmedButtonName => _armedButtonName;
+
+  private static volatile string? _armedButtonName;
+  private static nint _keyboardHook; // pump thread only
+  private static uint _pumpThreadId;
+  private static readonly ManualResetEventSlim _pumpReady = new(false);
+  private static readonly Lock _startLock = new();
+  private static bool _pumpStarted;
+  private static long _lastInvokeTimestamp;
+  private static readonly ConcurrentDictionary<uint, bool> _pidIsCmdPal = new();
+
+  internal static void Arm(string submitButtonName)
+  {
+    if (!HookingEnabled)
+      return;
+
+    _armedButtonName = submitButtonName;
+    try
+    {
+      EnsurePumpThread();
+      PostThreadMessageW(_pumpThreadId, WM_APP_INSTALL_HOOK, 0, 0);
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("EnterSubmit", $"Arm failed: {ex.GetType().Name}: {ex.Message}");
+    }
+  }
+
+  internal static void Disarm()
+  {
+    _armedButtonName = null;
+    if (_pumpStarted)
+      PostThreadMessageW(_pumpThreadId, WM_APP_UNINSTALL_HOOK, 0, 0);
+  }
+
+  private static void EnsurePumpThread()
+  {
+    if (_pumpStarted)
+      return;
+
+    lock (_startLock)
+    {
+      if (_pumpStarted)
+        return;
+
+      var thread = new Thread(PumpProc) { IsBackground = true, Name = "EnterKeySubmitHook" };
+      thread.Start();
+      _pumpReady.Wait(TimeSpan.FromSeconds(5));
+      _pumpStarted = true;
+    }
+  }
+
+  private static void PumpProc()
+  {
+    _pumpThreadId = GetCurrentThreadId();
+    // Force message queue creation before other threads post to us.
+    PeekMessageW(out _, 0, WM_USER, WM_USER, PM_NOREMOVE);
+    _pumpReady.Set();
+
+    // Foreground tracking so the keyboard hook never outlives a visible palette.
+    var winEventHook = SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND,
+        0, &WinEventProc, 0, 0, WINEVENT_OUTOFCONTEXT);
+
+    while (GetMessageW(out var msg, 0, 0, 0) > 0)
+    {
+      switch (msg.message)
+      {
+        case WM_APP_INSTALL_HOOK:
+          if (_keyboardHook == 0 && _armedButtonName != null)
+          {
+            _keyboardHook = SetWindowsHookExW(WH_KEYBOARD_LL, &HookProc, GetModuleHandleW(null), 0);
+            DebugLogService.Log("EnterSubmit", _keyboardHook != 0 ? "Keyboard hook installed" : $"SetWindowsHookEx failed: {Marshal.GetLastPInvokeError()}");
+          }
+          break;
+        case WM_APP_UNINSTALL_HOOK:
+          RemoveKeyboardHook();
+          break;
+        default:
+          TranslateMessage(in msg);
+          DispatchMessageW(in msg);
+          break;
+      }
+    }
+
+    RemoveKeyboardHook();
+    if (winEventHook != 0)
+      UnhookWinEvent(winEventHook);
+  }
+
+  private static void RemoveKeyboardHook()
+  {
+    if (_keyboardHook != 0)
+    {
+      UnhookWindowsHookEx(_keyboardHook);
+      _keyboardHook = 0;
+      DebugLogService.Log("EnterSubmit", "Keyboard hook removed");
+    }
+  }
+
+  [UnmanagedCallersOnly]
+  private static nint HookProc(int nCode, nuint wParam, nint lParam)
+  {
+    try
+    {
+      if (nCode >= 0
+          && (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN)
+          && _armedButtonName is string armed
+          && *(uint*)lParam == VK_RETURN)
+      {
+        var hwnd = GetForegroundWindow();
+        if (IsCommandPaletteWindow(hwnd) && TryClaimInvoke())
+          ThreadPool.QueueUserWorkItem(static state =>
+          {
+            var (h, name) = ((nint, string))state!;
+            TryInvokeSubmit(h, name);
+          }, (hwnd, armed));
+      }
+    }
+    catch
+    {
+      // Never let an exception escape a hook callback.
+    }
+    return CallNextHookEx(0, nCode, wParam, lParam);
+  }
+
+  [UnmanagedCallersOnly]
+  private static void WinEventProc(nint hWinEventHook, uint eventType, nint hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
+  {
+    try
+    {
+      if (eventType == EVENT_SYSTEM_FOREGROUND && _keyboardHook != 0 && !IsCommandPaletteWindow(hwnd))
+      {
+        _armedButtonName = null;
+        RemoveKeyboardHook(); // runs on the pump thread (out-of-context win event)
+      }
+    }
+    catch { }
+  }
+
+  // Suppresses bursts (key auto-repeat, queued work) and the double-submit race
+  // if upstream ever starts handling Enter natively.
+  private static bool TryClaimInvoke()
+  {
+    var now = Stopwatch.GetTimestamp();
+    var last = Interlocked.Read(ref _lastInvokeTimestamp);
+    if (last != 0 && Stopwatch.GetElapsedTime(last, now).TotalMilliseconds < 500)
+      return false;
+    return Interlocked.CompareExchange(ref _lastInvokeTimestamp, now, last) == last;
+  }
+
+  private static bool IsCommandPaletteWindow(nint hwnd)
+  {
+    if (hwnd == 0)
+      return false;
+    GetWindowThreadProcessId(hwnd, out var pid);
+    if (pid == 0)
+      return false;
+
+    if (_pidIsCmdPal.TryGetValue(pid, out var cached))
+      return cached;
+
+    bool isCmdPal;
+    try
+    {
+      using var process = Process.GetProcessById((int)pid);
+      isCmdPal = process.ProcessName.Contains("CmdPal", StringComparison.OrdinalIgnoreCase);
+    }
+    catch
+    {
+      return false;
+    }
+
+    if (_pidIsCmdPal.Count > 64)
+      _pidIsCmdPal.Clear();
+    _pidIsCmdPal[pid] = isCmdPal;
+    return isCmdPal;
+  }
+
+  private static void TryInvokeSubmit(nint hwnd, string buttonName)
+  {
+    IUIAutomation? automation = null;
+    IUIAutomationElement? focused = null;
+    IUIAutomationElement? root = null;
+    IUIAutomationCondition? typeCondition = null;
+    IUIAutomationCondition? nameCondition = null;
+    IUIAutomationCondition? condition = null;
+    IUIAutomationElement? button = null;
+    object? patternObj = null;
+    try
+    {
+#pragma warning disable IL2072 // COM activation via CLSID is inherently dynamic
+      automation = (IUIAutomation)Activator.CreateInstance(
+          Type.GetTypeFromCLSID(new Guid("ff48dba4-60ef-4201-aa87-54103eef594e"))!)!;
+#pragma warning restore IL2072
+
+      if (automation.GetFocusedElement(out focused) != 0 || focused == null)
+        return;
+
+      if (!FocusedElementIsOurTextInput(focused, hwnd))
+        return;
+
+      if (automation.ElementFromHandle(hwnd, out root) != 0 || root == null)
+        return;
+
+      if (automation.CreatePropertyCondition(UIA_ControlTypePropertyId, UIA_ButtonControlTypeId, out typeCondition) != 0 || typeCondition == null)
+        return;
+      if (automation.CreatePropertyCondition(UIA_NamePropertyId, buttonName, out nameCondition) != 0 || nameCondition == null)
+        return;
+      if (automation.CreateAndCondition(typeCondition, nameCondition, out condition) != 0 || condition == null)
+        return;
+
+      if (root.FindFirst(TreeScope_Descendants, condition, out button) != 0 || button == null)
+      {
+        DebugLogService.Log("EnterSubmit", $"Submit button '{buttonName}' not found");
+        return;
+      }
+
+      if (button.GetCurrentPattern(UIA_InvokePatternId, out patternObj) != 0 || patternObj is not IUIAutomationInvokePattern invoke)
+        return;
+
+      invoke.Invoke();
+      DebugLogService.Log("EnterSubmit", $"Invoked '{buttonName}' via Enter");
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("EnterSubmit", $"Invoke failed: {ex.GetType().Name}: {ex.Message}");
+    }
+    finally
+    {
+      if (patternObj != null) Marshal.ReleaseComObject(patternObj);
+      if (button != null) Marshal.ReleaseComObject(button);
+      if (condition != null) Marshal.ReleaseComObject(condition);
+      if (nameCondition != null) Marshal.ReleaseComObject(nameCondition);
+      if (typeCondition != null) Marshal.ReleaseComObject(typeCondition);
+      if (root != null) Marshal.ReleaseComObject(root);
+      if (focused != null) Marshal.ReleaseComObject(focused);
+      if (automation != null) Marshal.ReleaseComObject(automation);
+    }
+  }
+
+  // Only invoke when focus sits in a text input owned by the Command Palette
+  // process: a password box (unlock/verify) or a plain edit (the login email
+  // field, which the renderer focuses first). This stops a stale armed state
+  // from clicking anything when focus is on a button or another window.
+  private static bool FocusedElementIsOurTextInput(IUIAutomationElement focused, nint cmdPalHwnd)
+  {
+    GetWindowThreadProcessId(cmdPalHwnd, out var cmdPalPid);
+    if (focused.GetCurrentPropertyValue(UIA_ProcessIdPropertyId, out var pidValue) != 0
+        || pidValue is not int focusedPid
+        || focusedPid != (int)cmdPalPid)
+      return false;
+
+    if (focused.GetCurrentPropertyValue(UIA_IsPasswordPropertyId, out var isPassword) == 0
+        && isPassword is bool password && password)
+      return true;
+
+    return focused.GetCurrentPropertyValue(UIA_ControlTypePropertyId, out var controlType) == 0
+        && controlType is int type
+        && type == UIA_EditControlTypeId;
+  }
+
+  private const uint WM_USER = 0x0400;
+  private const uint WM_APP_INSTALL_HOOK = 0x8001;
+  private const uint WM_APP_UNINSTALL_HOOK = 0x8002;
+  private const uint WM_KEYDOWN = 0x0100;
+  private const uint WM_SYSKEYDOWN = 0x0104;
+  private const uint VK_RETURN = 0x0D;
+  private const int WH_KEYBOARD_LL = 13;
+  private const uint PM_NOREMOVE = 0;
+  private const uint EVENT_SYSTEM_FOREGROUND = 0x0003;
+  private const uint WINEVENT_OUTOFCONTEXT = 0;
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct MSG
+  {
+    public nint hwnd;
+    public uint message;
+    public nuint wParam;
+    public nint lParam;
+    public uint time;
+    public int ptX;
+    public int ptY;
+  }
+
+  [LibraryImport("user32.dll")]
+  private static partial nint GetForegroundWindow();
+
+  [LibraryImport("user32.dll")]
+  private static partial uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
+
+  [LibraryImport("user32.dll", SetLastError = true)]
+  private static partial nint SetWindowsHookExW(int idHook, delegate* unmanaged<int, nuint, nint, nint> lpfn, nint hMod, uint dwThreadId);
+
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool UnhookWindowsHookEx(nint hhk);
+
+  [LibraryImport("user32.dll")]
+  private static partial nint CallNextHookEx(nint hhk, int nCode, nuint wParam, nint lParam);
+
+  [LibraryImport("user32.dll")]
+  private static partial int GetMessageW(out MSG lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool PeekMessageW(out MSG lpMsg, nint hWnd, uint wMsgFilterMin, uint wMsgFilterMax, uint wRemoveMsg);
+
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool TranslateMessage(in MSG lpMsg);
+
+  [LibraryImport("user32.dll")]
+  private static partial nint DispatchMessageW(in MSG lpMsg);
+
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool PostThreadMessageW(uint idThread, uint msg, nuint wParam, nint lParam);
+
+  [LibraryImport("user32.dll")]
+  private static partial nint SetWinEventHook(uint eventMin, uint eventMax, nint hmodWinEventProc, delegate* unmanaged<nint, uint, nint, int, int, uint, uint, void> pfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool UnhookWinEvent(nint hWinEventHook);
+
+  [LibraryImport("kernel32.dll")]
+  private static partial uint GetCurrentThreadId();
+
+  [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16)]
+  private static partial nint GetModuleHandleW(string? lpModuleName);
+
+  private const int UIA_ProcessIdPropertyId = 30002;
+  private const int UIA_ControlTypePropertyId = 30003;
+  private const int UIA_NamePropertyId = 30005;
+  private const int UIA_IsPasswordPropertyId = 30019;
+  private const int UIA_ButtonControlTypeId = 50000;
+  private const int UIA_EditControlTypeId = 50004;
+  private const int UIA_InvokePatternId = 10000;
+  private const int TreeScope_Descendants = 4;
+
+  // Minimal COM interface definitions — only the methods we call are properly declared;
+  // unused vtable slots use parameterless void stubs for slot positioning.
+  // (Same pattern as ContextAwarenessService.)
+
+  [ComImport, Guid("30cbe57d-d9d0-452a-ab13-7ac5ac4825ee")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IUIAutomation
+  {
+    void _ReservedCompareElements();
+    void _ReservedCompareRuntimeIds();
+    void _ReservedGetRootElement();
+
+    [PreserveSig]
+    int ElementFromHandle(nint hwnd, [MarshalAs(UnmanagedType.Interface)] out IUIAutomationElement element);
+
+    void _ReservedElementFromPoint();
+
+    [PreserveSig]
+    int GetFocusedElement([MarshalAs(UnmanagedType.Interface)] out IUIAutomationElement element);
+
+    void _ReservedGetRootElementBuildCache();
+    void _ReservedElementFromHandleBuildCache();
+    void _ReservedElementFromPointBuildCache();
+    void _ReservedGetFocusedElementBuildCache();
+    void _ReservedCreateTreeWalker();
+    void _ReservedControlViewWalker();
+    void _ReservedContentViewWalker();
+    void _ReservedRawViewWalker();
+    void _ReservedRawViewCondition();
+    void _ReservedControlViewCondition();
+    void _ReservedContentViewCondition();
+    void _ReservedCreateCacheRequest();
+    void _ReservedCreateTrueCondition();
+    void _ReservedCreateFalseCondition();
+
+    [PreserveSig]
+    int CreatePropertyCondition(
+        int propertyId,
+        [In, MarshalAs(UnmanagedType.Struct)] object value,
+        [MarshalAs(UnmanagedType.Interface)] out IUIAutomationCondition condition);
+
+    void _ReservedCreatePropertyConditionEx();
+
+    [PreserveSig]
+    int CreateAndCondition(
+        [MarshalAs(UnmanagedType.Interface)] IUIAutomationCondition condition1,
+        [MarshalAs(UnmanagedType.Interface)] IUIAutomationCondition condition2,
+        [MarshalAs(UnmanagedType.Interface)] out IUIAutomationCondition condition);
+  }
+
+  [ComImport, Guid("d22108aa-8ac5-49a5-837b-37bbb3d7591e")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IUIAutomationElement
+  {
+    void _ReservedSetFocus();
+    void _ReservedGetRuntimeId();
+
+    [PreserveSig]
+    int FindFirst(
+        int scope,
+        [MarshalAs(UnmanagedType.Interface)] IUIAutomationCondition condition,
+        [MarshalAs(UnmanagedType.Interface)] out IUIAutomationElement found);
+
+    void _ReservedFindAll();
+    void _ReservedFindFirstBuildCache();
+    void _ReservedFindAllBuildCache();
+    void _ReservedBuildUpdatedCache();
+
+    [PreserveSig]
+    int GetCurrentPropertyValue(int propertyId, [MarshalAs(UnmanagedType.Struct)] out object value);
+
+    void _ReservedGetCurrentPropertyValueEx();
+    void _ReservedGetCachedPropertyValue();
+    void _ReservedGetCachedPropertyValueEx();
+    void _ReservedGetCurrentPatternAs();
+    void _ReservedGetCachedPatternAs();
+
+    [PreserveSig]
+    int GetCurrentPattern(int patternId, [MarshalAs(UnmanagedType.IUnknown)] out object pattern);
+  }
+
+  [ComImport, Guid("352ffba8-0973-437c-a61f-f64cafd81df9")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IUIAutomationCondition { }
+
+  [ComImport, Guid("fb377fbe-8ea6-46d5-9c73-6499642d3059")]
+  [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  private interface IUIAutomationInvokePattern
+  {
+    [PreserveSig]
+    int Invoke();
+  }
+}


### PR DESCRIPTION
## Summary

Submit the unlock, login and master-password-reprompt forms by pressing Enter, working around [microsoft/PowerToys#46003](https://github.com/microsoft/PowerToys/issues/46003) (Command Palette doesn't wire Enter to `Action.Submit` on rendered Adaptive Card forms). The extension runs out-of-process, so there's no host UI thread to hook from inside; instead a scoped Win32 keyboard hook plus UI Automation drives the form's submit button.

## Changes

- New `EnterKeySubmitService`: while a form is open, a `WH_KEYBOARD_LL` hook (on its own message-pump thread) watches for Enter and, only when Command Palette is foreground with one of our text inputs focused, invokes the form's submit button via UI Automation. The hook is installed only while a form is armed and removed as soon as the palette loses focus (tracked with `EVENT_SYSTEM_FOREGROUND`). No keystrokes are read or recorded.
- Pages arm on `GetContent()` and disarm on submit; the now-redundant "upvote this issue" hint is removed from the unlock and login forms.
- Migrated `.github/copilot-instructions.md` to `AGENTS.md` (read by both Copilot and Claude Code) and added a Local Build & Deploy section, including the worktree re-registration gotcha; added `CLAUDE.md` importing it.
- Made the grace-period persistence test hermetic (clears any stale `grace.json` first) and excluded the new interop service from coverage.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing with PowerToys Command Palette
- [x] Existing tests pass (`dotnet test -p:Platform=x64`) — 505/505

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
- [x] Changed `.cs` files meet the 50% coverage threshold
- [x] Wiki docs updated (if behavior/settings changed) — n/a, no user-facing setting or documented behaviour changed

chore: migrate Copilot instructions to AGENTS.md and add CLAUDE.md import
