### PR TITLE
fix: 🐛 stop background Windows Hello prompt at startup and show (Prerelease) name

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtensionCommandsProvider.cs
+++ b/HoobiBitwardenCommandPaletteExtension/HoobiBitwardenCommandPaletteExtensionCommandsProvider.cs
@@ -14,8 +14,10 @@ public partial class HoobiBitwardenCommandPaletteExtensionCommandsProvider : Com
 
     public HoobiBitwardenCommandPaletteExtensionCommandsProvider()
     {
-#if DEBUG
+#if CHANNEL_DEV
         DisplayName = "Bitwarden (Dev)";
+#elif CHANNEL_PRERELEASE
+        DisplayName = "Bitwarden (Prerelease)";
 #else
         DisplayName = "Bitwarden";
 #endif
@@ -27,8 +29,10 @@ public partial class HoobiBitwardenCommandPaletteExtensionCommandsProvider : Com
         _commands = [
             new CommandItem(new HoobiBitwardenCommandPaletteExtensionPage(_service, _settingsManager))
             {
-#if DEBUG
+#if CHANNEL_DEV
                 Title = "Bitwarden (Dev)",
+#elif CHANNEL_PRERELEASE
+                Title = "Bitwarden (Prerelease)",
 #else
                 Title = "Bitwarden",
 #endif

--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -1134,6 +1134,15 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         if (_autoBiometricTriggered || _biometricClickFailed || _handlingAction)
             return;
 
+        // Only auto-trigger in the foreground. The startup warmup completes on a
+        // background thread and fires WarmupCompleted -> RebuildForCurrentStatus
+        // before the user has opened the palette; prompting for Windows Hello then
+        // pops a verification dialog the user has no context for. _initialLoadStarted
+        // flips only when the user actually opens the page (GetItems) or changes the
+        // CLI config, so it gates this to genuine foreground interactions.
+        if (!_initialLoadStarted)
+            return;
+
         var biometricEnabled = _settings?.UseDesktopIntegration.Value == true
                             && _settings?.AutoBiometricUnlock.Value == true;
         var rememberSession = _settings?.RememberSession.Value == true;


### PR DESCRIPTION
## Summary

Two unrelated startup/packaging fixes.

## Changes

- Gate `TryAutoTriggerBiometric` on `_initialLoadStarted` so Windows Hello only prompts when the user has opened the palette. The startup warmup completes on a background thread and fired `WarmupCompleted -> RebuildForCurrentStatus` before any interaction, popping a Hello prompt with no context. Silent session restore still runs in the background warmup, so RememberSession is unaffected.
- Key the Command Palette provider `DisplayName` and command `Title` off the `CHANNEL_*` constants instead of `#if DEBUG`. Prerelease builds are a Release configuration, so they fell through to the bare "Bitwarden" with no "(Prerelease)" suffix. (The MSIX manifest was already stamped correctly; this only affected the in-app name.)

## Testing

- [x] Existing tests pass / builds clean (`win-x64`, default and `PackageChannel=Prerelease`)
- [x] Manual testing with PowerToys Command Palette

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings
