### PR TITLE
fix: 🐛 stop one-click install from clobbering the user's CLI path override (#178)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,18 +30,34 @@ Debug builds install as a separate **Dev** channel (`Hoobi.BitwardenCommandPalet
 
 `Add-AppxPackage -Register` deduplicates on package **identity + version**. The Dev identity and version (`1.10.0.0`) are the same across every checkout, so if a Dev package is already registered (e.g. pointing at the main checkout's `bin`), registering again from a worktree's `bin` is silently skipped (`Deployed.` prints, but `InstallLocation` does not change). You then run old code and think the change "did nothing".
 
-When deploying from a worktree, force the registration to repoint:
+When deploying from a worktree, **always remove-then-register and then verify** - registering in place is silently skipped:
 
 ```powershell
-# Confirm where the Dev package currently points
-(Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev').InstallLocation
+# 1. Remove any existing Dev registration (wherever it points), then register from THIS worktree
+Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev' | Remove-AppxPackage -ErrorAction SilentlyContinue
+$out = "<worktree>\HoobiBitwardenCommandPaletteExtension\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64"
+Add-AppxPackage -Register -Path "$out\AppxManifest.xml" -ForceUpdateFromAnyVersion
 
-# If it isn't your worktree bin: remove it, then re-register from the worktree
-Remove-AppxPackage -Package (Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev').PackageFullName
-Add-AppxPackage -Register -Path "<worktree>\HoobiBitwardenCommandPaletteExtension\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64\AppxManifest.xml" -ForceUpdateFromAnyVersion
+# 2. VERIFY (do not skip): identity must be .Dev and InstallLocation must be your worktree bin
+$p = Get-AppxPackage -Name 'Hoobi.BitwardenCommandPaletteExtension.Dev'
+"$($p.Name) -> $($p.InstallLocation)"   # Name must end in .Dev; path must be your worktree
 ```
 
-Stamping note: a Debug build rewrites `Package.appxmanifest` to the Dev identity as a side effect. Don't commit that change. If the generated output `AppxManifest.xml` ever goes stale (shows the Release identity), delete `bin\...\win-x64\AppxManifest.xml` and `bin\...\win-x64\AppX` and rebuild to regenerate it.
+If `Name` has no `.Dev` suffix, or `InstallLocation` is not your worktree, the deploy is wrong - do not stop there.
+
+### Release-build trap (this is the one that bites)
+
+The per-channel identity is stamped into `Package.appxmanifest` at build time, and the stamp is **incremental**. If you run a `-c Release` build first (e.g. for lint/test parity) and then a `-c Debug` build in the same checkout, the Debug build can skip regenerating the output `AppxManifest.xml`, leaving it stamped with the **Release** identity. Registering that loose layout installs the *production* channel from your Debug bin - exactly the "I deployed but nothing changed / wrong channel" symptom.
+
+Guard against it: when deploying from a worktree, do a clean Debug build with the channel pinned explicitly, and check the output manifest before registering:
+
+```powershell
+Remove-Item -Recurse -Force "<worktree>\HoobiBitwardenCommandPaletteExtension\bin\x64\Debug" -ErrorAction SilentlyContinue
+dotnet build .\HoobiBitwardenCommandPaletteExtension\HoobiBitwardenCommandPaletteExtension.csproj -c Debug /p:Platform=x64 /p:PackageChannel=Dev
+Select-String -Path "$out\AppxManifest.xml" -Pattern '<Identity Name'   # must show ...Extension.Dev
+```
+
+Stamping note: a Debug build rewrites the tracked `Package.appxmanifest` to the Dev identity as a side effect. **Don't commit that change** - `git checkout -- HoobiBitwardenCommandPaletteExtension/Package.appxmanifest` before committing.
 
 ## Git Commit Message Format
 

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -38,6 +40,47 @@ public class BitwardenCliServiceTests
   {
     var result = BitwardenCliService.ResolveCliExecutable(@"C:\tools\bw-windows-2026.2.0\bw");
     Assert.Equal(@"C:\tools\bw-windows-2026.2.0\bw", result);
+  }
+
+  [Fact]
+  public void ResolveCliExecutable_UserOverride_WinsOverAutoInstalled()
+  {
+    var autoInstalled = Path.Combine(Path.GetTempPath(), $"bw_auto_{Guid.NewGuid():N}", "bw.exe");
+    Directory.CreateDirectory(Path.GetDirectoryName(autoInstalled)!);
+    File.WriteAllText(autoInstalled, "stub");
+    try
+    {
+      var result = BitwardenCliService.ResolveCliExecutable(@"C:\tools\custom\bw.exe", autoInstalled);
+      Assert.Equal(@"C:\tools\custom\bw.exe", result);
+    }
+    finally
+    {
+      Directory.Delete(Path.GetDirectoryName(autoInstalled)!, recursive: true);
+    }
+  }
+
+  [Fact]
+  public void ResolveCliExecutable_NoOverride_UsesAutoInstalledWhenItExists()
+  {
+    var autoInstalled = Path.Combine(Path.GetTempPath(), $"bw_auto_{Guid.NewGuid():N}", "bw.exe");
+    Directory.CreateDirectory(Path.GetDirectoryName(autoInstalled)!);
+    File.WriteAllText(autoInstalled, "stub");
+    try
+    {
+      var result = BitwardenCliService.ResolveCliExecutable(null, autoInstalled);
+      Assert.Equal(autoInstalled, result);
+    }
+    finally
+    {
+      Directory.Delete(Path.GetDirectoryName(autoInstalled)!, recursive: true);
+    }
+  }
+
+  [Fact]
+  public void ResolveCliExecutable_NoOverride_FallsBackToBwWhenAutoInstalledMissing()
+  {
+    var missing = Path.Combine(Path.GetTempPath(), $"bw_missing_{Guid.NewGuid():N}", "bw.exe");
+    Assert.Equal("bw", BitwardenCliService.ResolveCliExecutable(null, missing));
   }
 
   // --- ResolveDataDirectory ---

--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenSettingsManagerTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenSettingsManagerTests.cs
@@ -56,6 +56,29 @@ public class BitwardenSettingsManagerTests : IDisposable
     }
 
     [Fact]
+    public void PersistCliPath_DoesNotOverwriteUserOverride()
+    {
+        var m = CreateManager();
+        m.CliDirectoryOverride.Value = @"C:\Users\me\scoop\apps\bitwarden-cli\current\bw.exe";
+
+        m.PersistCliPath(@"C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\Bitwarden.CLI_x\bw.exe");
+
+        Assert.Equal(@"C:\Users\me\scoop\apps\bitwarden-cli\current\bw.exe", m.CliDirectoryOverride.Value);
+    }
+
+    [Fact]
+    public void PersistCliPath_RoundTripsThroughAutoInstalledCliPath()
+    {
+        var m = CreateManager();
+        Assert.Null(m.AutoInstalledCliPath);
+
+        var path = @"C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\Bitwarden.CLI_x\bw.exe";
+        m.PersistCliPath(path);
+
+        Assert.Equal(path, m.AutoInstalledCliPath);
+    }
+
+    [Fact]
     public void OnSettingsChanged_DoesNotClearSession_DirectlyInSettingsManager()
     {
         var m = CreateManager();

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -75,12 +75,31 @@ internal sealed partial class BitwardenCliService
     IconsUrl = null;
   }
 
-  internal static string ResolveCliExecutable(string? pathOverride)
+  // Resolution order: the user's explicit override always wins (even if broken,
+  // so a misconfiguration surfaces a clear error rather than silently falling
+  // back). Otherwise use the path an automated install remembered, but only if
+  // it still exists. Finally fall back to "bw" on PATH. The user override and the
+  // auto-installed path are kept in separate stores so a one-click install can
+  // never overwrite a path the user set by hand (issue #178).
+  internal static string ResolveCliExecutable(string? pathOverride, string? autoInstalledPath = null)
   {
-    if (string.IsNullOrWhiteSpace(pathOverride))
-      return "bw";
+    var explicitPath = NormalizeCliPath(pathOverride);
+    if (explicitPath != null)
+      return explicitPath;
 
-    var trimmed = pathOverride.Trim();
+    var auto = NormalizeCliPath(autoInstalledPath);
+    if (auto != null && File.Exists(auto))
+      return auto;
+
+    return "bw";
+  }
+
+  private static string? NormalizeCliPath(string? path)
+  {
+    if (string.IsNullOrWhiteSpace(path))
+      return null;
+
+    var trimmed = path.Trim();
     var name = Path.GetFileName(trimmed);
     if (name.Equals("bw", StringComparison.OrdinalIgnoreCase)
         || name.Equals("bw.exe", StringComparison.OrdinalIgnoreCase))
@@ -107,7 +126,9 @@ internal sealed partial class BitwardenCliService
     return null;
   }
 
-  private string CliExecutable => ResolveCliExecutable(_settings?.CliDirectoryOverride.Value);
+  private string CliExecutable => ResolveCliExecutable(
+    _settings?.CliDirectoryOverride.Value,
+    _settings?.AutoInstalledCliPath);
 
   private string? DataDirectory => ResolveDataDirectory(
     _settings?.CliDirectoryOverride.Value,
@@ -188,10 +209,12 @@ internal sealed partial class BitwardenCliService
     ResetForCliConfigChange();
   }
 
-  // Apply a path produced by BitwardenCliInstaller: persist it as the CLI override
-  // and re-resolve. CheckCliConfigChanged sees the changed executable and fires
-  // ResetForCliConfigChange -> CliConfigChanged, which the page handles by
-  // re-checking vault status against the freshly installed CLI.
+  // Apply a path produced by BitwardenCliInstaller: remember it as the
+  // auto-installed CLI path (kept separate from the user's CLI Path Override so it
+  // can never clobber a hand-set value) and re-resolve. CheckCliConfigChanged sees
+  // the changed executable and fires ResetForCliConfigChange -> CliConfigChanged,
+  // which the page handles by re-checking vault status against the freshly
+  // installed CLI.
   public void ApplyInstalledCli(string path)
   {
     _settings?.PersistCliPath(path);

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenSettingsManager.cs
@@ -240,13 +240,47 @@ internal sealed class BitwardenSettingsManager : JsonSettingsManager
         LogConfig("startup");
     }
 
-    // Programmatic settings changes (e.g. writing the resolved path after an
-    // automated CLI install) don't flow through the settings form, so persist
-    // explicitly here. BitwardenCliService.ApplyInstalledCli then re-resolves.
+    // The path a one-click install resolved to. Stored separately from the
+    // user-facing CliDirectoryOverride so an automated install can never overwrite
+    // a path the user set by hand (issue #178). Lives next to settings.json rather
+    // than inside it, since it's internal state and must not surface in the form.
+    private string AutoInstalledCliPathFile => Path.Combine(
+        Path.GetDirectoryName(FilePath) is { Length: > 0 } dir ? dir : SettingsDir,
+        "cli_install_path");
+
+    public string? AutoInstalledCliPath
+    {
+        get
+        {
+            try
+            {
+                return File.Exists(AutoInstalledCliPathFile)
+                    ? File.ReadAllText(AutoInstalledCliPathFile).Trim()
+                    : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    // Records the path resolved by an automated CLI install. Kept out of the
+    // settings form and the user's CliDirectoryOverride; BitwardenCliService falls
+    // back to it only when the user hasn't set an explicit override.
     public void PersistCliPath(string path)
     {
-        CliDirectoryOverride.Value = path;
-        SaveSettings();
+        try
+        {
+            var dir = Path.GetDirectoryName(AutoInstalledCliPathFile);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(AutoInstalledCliPathFile, path);
+        }
+        catch (Exception ex)
+        {
+            DebugLogService.Log("Installer", $"Failed to persist auto-installed CLI path: {ex.GetType().Name}: {ex.Message}");
+        }
     }
 
     private void OnSettingsChanged(object sender, Settings e)

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -128,7 +128,7 @@ Open settings from the gear icon in the vault browser. All settings take effect 
 |---|---|
 | **Type** | Text |
 | **Default** | *(empty)* |
-| **Description** | Path to the Bitwarden CLI. Accepts a directory containing `bw`, or a direct path to `bw`/`bw.exe` (e.g. `C:\tools\bw-portable` or `C:\tools\bw-portable\bw.exe`). Leave empty to use the default PATH-based resolution. |
+| **Description** | Path to the Bitwarden CLI. Accepts a directory containing `bw`, or a direct path to `bw`/`bw.exe` (e.g. `C:\tools\bw-portable` or `C:\tools\bw-portable\bw.exe`). Leave empty to use the default PATH-based resolution. When set, this always takes precedence over a CLI installed via the one-click installer, and the installer never overwrites it. |
 
 ### Use CLI Path as Data Directory
 


### PR DESCRIPTION
## Summary

Fixes #178. A custom CLI path set in **CLI Path Override** was silently overwritten by the one-click installer, so the configured path was ignored and the winget-installed copy got used instead.

## Root cause

The one-click installer (added in #171, shipped in 1.10.0) calls `ApplyInstalledCli` -> `PersistCliPath`, which wrote the resolved path straight into the user-facing `cliDirectoryOverride` setting. Installing or re-installing the CLI therefore clobbered whatever path the user had set by hand. A user pointing the override at their Scoop `bw.exe` ended up running the winget copy.

## Changes

- `PersistCliPath` now records the auto-installed path in a separate store (`cli_install_path`, next to `settings.json`) instead of the user-facing override.
- `ResolveCliExecutable` resolves in order: explicit user override -> remembered auto-installed path (only if it still exists) -> `bw` on PATH. The user override always wins and the installer never touches it.
- Updated the CLI Path Override docs.

## Testing

- [x] Unit tests added/updated (precedence + that `PersistCliPath` leaves the override untouched)
- [x] Manual testing with PowerToys Command Palette
- [x] Existing tests pass (`dotnet test -p:Platform=x64`) - 510 passed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code builds without warnings (`dotnet build -c Release -p:Platform=x64`)
- [x] Changed `.cs` files meet the 50% coverage threshold
- [x] Wiki docs updated (if behavior/settings changed)