### PR TITLE
fix: detect a PATH-installed Bitwarden CLI without a reboot

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliInstallerTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliInstallerTests.cs
@@ -94,15 +94,34 @@ public class BitwardenCliInstallerTests
   // --- static helpers ---
 
   [Fact]
-  public void GetCandidateCliPaths_IncludesWingetLinksAndAppDataInstallDir()
+  public void GetCandidateCliPaths_IncludesAppDataInstallDir_NotLinksShim()
   {
     var paths = BitwardenCliInstaller.GetCandidateCliPaths()
         .Select(p => p.Replace('\\', '/'))
         .ToList();
 
-    Assert.Contains(paths, p => p.Contains("Microsoft/WinGet/Links/bw.exe", StringComparison.OrdinalIgnoreCase));
     Assert.Contains(paths, p => p.Contains("HoobiBitwardenCommandPalette/cli/bw.exe", StringComparison.OrdinalIgnoreCase));
+    // The WinGet\Links\bw.exe symlink shim is deliberately excluded (bw can't run through it).
+    Assert.DoesNotContain(paths, p => p.Contains("Microsoft/WinGet/Links/bw.exe", StringComparison.OrdinalIgnoreCase));
     Assert.All(paths, p => Assert.EndsWith("bw.exe", p, StringComparison.OrdinalIgnoreCase));
+  }
+
+  [Fact]
+  public void GetCandidateCliPaths_IncludesDirsFromProcessPath()
+  {
+    var original = Environment.GetEnvironmentVariable("PATH");
+    try
+    {
+      Environment.SetEnvironmentVariable("PATH", @"C:\hoobi-test-cli-dir");
+      var paths = BitwardenCliInstaller.GetCandidateCliPaths()
+          .Select(p => p.Replace('\\', '/'))
+          .ToList();
+      Assert.Contains(paths, p => p.Equals("C:/hoobi-test-cli-dir/bw.exe", StringComparison.OrdinalIgnoreCase));
+    }
+    finally
+    {
+      Environment.SetEnvironmentVariable("PATH", original);
+    }
   }
 
   [Fact]

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliInstaller.cs
@@ -207,7 +207,6 @@ internal sealed class BitwardenCliInstaller
   internal static IEnumerable<string> GetCandidateCliPaths()
   {
     var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-    yield return Path.Combine(localAppData, "Microsoft", "WinGet", "Links", "bw.exe");
     yield return Path.Combine(localAppData, "HoobiBitwardenCommandPalette", "cli", "bw.exe");
     yield return Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "scoop", "shims", "bw.exe");
@@ -216,13 +215,42 @@ internal sealed class BitwardenCliInstaller
     if (!string.IsNullOrEmpty(programData))
       yield return Path.Combine(programData, "chocolatey", "bin", "bw.exe");
 
-    var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-    foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+    // Exclude the WinGet\Links\bw.exe symlink shim everywhere - including when it's
+    // on PATH, which it is for winget users. bw (a Node single-file exe) can't
+    // locate its bundled snapshot when launched through the shim, so `bw --version`
+    // fails; resolving to it is the exact "didn't respond yet" failure.
+    // WingetPackagesCliPath already covers the real winget exe.
+    var linksShim = Path.Combine(localAppData, "Microsoft", "WinGet", "Links", "bw.exe");
+    foreach (var dir in PathDirectories())
     {
       var candidate = TryCombine(dir, "bw.exe");
-      if (candidate != null)
+      if (candidate != null && !string.Equals(candidate, linksShim, StringComparison.OrdinalIgnoreCase))
         yield return candidate;
     }
+  }
+
+  // PATH directories from the process snapshot plus the live User/Machine registry
+  // values. The process copy is frozen at launch, so a folder added to PATH after
+  // the host started - the manual-install flow - is only visible via the registry
+  // targets. Reading them is the "reimport" that lets us find a hand-placed bw
+  // without a reboot.
+  internal static IEnumerable<string> PathDirectories()
+  {
+    var sources = new List<string?> { Environment.GetEnvironmentVariable("PATH") };
+    try
+    {
+      sources.Add(Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User));
+      sources.Add(Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine));
+    }
+    catch (Exception ex)
+    {
+      DebugLogService.Log("Installer", $"Registry PATH read failed: {ex.GetType().Name}: {ex.Message}");
+    }
+
+    return sources
+        .Where(p => !string.IsNullOrEmpty(p))
+        .SelectMany(p => p!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        .Distinct(StringComparer.OrdinalIgnoreCase);
   }
 
   private static string? TryCombine(string dir, string file)


### PR DESCRIPTION
A manually-installed CLI added to PATH stayed invisible to the extension even after restarting PowerToys, because the location probe only read the process PATH (a launch-time snapshot). "Retry automatic install" then fell back to winget and could resolve the `WinGet\Links\bw.exe` symlink shim, which bw cannot run through, producing the "Installed, but the CLI didn't respond yet" message.

- Reimport PATH from the live User/Machine registry targets in addition to the process snapshot, so a hand-placed `bw` is found without a reboot.
- Exclude the `WinGet\Links\bw.exe` shim from every source (including PATH); `WingetPackagesCliPath` already covers the real winget exe.

Tests updated and passing.