### PR TITLE
ci: add Microsoft Store publish workflow

### DIFF
--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -1,0 +1,160 @@
+name: Publish to Microsoft Store
+
+# Bundles the per-arch .msix that the release already ships into a single signed
+# .msixbundle, attaches it to the GitHub release, and publishes it (plus the
+# WHATS_NEW.md release notes) to the Store via the msstore CLI.
+#
+# The Store path uses a bundle because the msstore CLI uploads exactly one package
+# file per submission and matches existing packages by extension - two loose .msix
+# can't both update in one submission, but one .msixbundle can.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to (re)publish (e.g. v1.11.0)
+        required: true
+
+permissions:
+  contents: write # upload the .msixbundle asset onto the release
+
+env:
+  STORE_PRODUCT_ID: 9P5KS8T80MV3
+  ASSET_BASE_NAME: HoobiBitwardenCommandPaletteExtension
+  WHATS_NEW_PATH: HoobiBitwardenCommandPaletteExtension/Assets/WHATS_NEW.md
+
+jobs:
+  store-publish:
+    name: Bundle, attach to release, publish to Store
+    # Free-product GitHub Actions publishing only; skip prereleases.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    runs-on: windows-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.inputs.tag }}'
+          if (-not $tag) { $tag = '${{ github.event.release.tag_name }}' }
+          if (-not $tag) { throw 'No release tag resolved' }
+          "tag=$tag"                       | Out-File -Append $env:GITHUB_OUTPUT
+          "version=$($tag.TrimStart('v'))" | Out-File -Append $env:GITHUB_OUTPUT
+
+      - name: Checkout at tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Download release MSIX assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path packages | Out-Null
+          gh release download '${{ steps.tag.outputs.tag }}' `
+            --repo '${{ github.repository }}' --pattern '*.msix' --dir packages
+          $msix = Get-ChildItem packages -Filter *.msix
+          if ($msix.Count -lt 1) { throw "No .msix assets on release ${{ steps.tag.outputs.tag }}" }
+          $msix | ForEach-Object { Write-Host "Downloaded $($_.Name)" }
+
+      - name: Build signed .msixbundle
+        id: bundle
+        env:
+          PFX_BASE64: ${{ secrets.SIGNING_CERTIFICATE }}
+          PFX_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
+          THUMBPRINT: ${{ vars.SIGNING_CERT_THUMBPRINT }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Newest x64 makeappx + signtool from the Windows SDK.
+          $kit = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          function Resolve-SdkTool($name) {
+            Get-ChildItem $kit -Recurse -Filter $name -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match '\\x64\\' } |
+              Sort-Object { [version]($_.FullName -replace '.*\\(\d+\.\d+\.\d+\.\d+)\\.*', '$1') } -Descending |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+          $makeappx = Resolve-SdkTool 'makeappx.exe'
+          $signtool = Resolve-SdkTool 'signtool.exe'
+          if (-not $makeappx -or -not $signtool) { throw 'Windows SDK tooling not found' }
+
+          $bundle = Join-Path $PWD "$env:ASSET_BASE_NAME-$env:VERSION.msixbundle"
+          & $makeappx bundle /d packages /p $bundle /bv "$env:VERSION.0" /o
+          if ($LASTEXITCODE -ne 0) { throw "makeappx bundle failed ($LASTEXITCODE)" }
+
+          # Release assets get sideloaded, so the bundle must carry the cert.
+          # (The Store re-signs on its end, so a signed bundle is fine there too.)
+          $pfx = Join-Path $env:RUNNER_TEMP ([guid]::NewGuid().ToString('N') + '.pfx')
+          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:PFX_BASE64))
+          try {
+            $sec = ConvertTo-SecureString $env:PFX_PASSWORD -AsPlainText -Force
+            Import-PfxCertificate -FilePath $pfx -CertStoreLocation Cert:\CurrentUser\My -Password $sec | Out-Null
+          } finally { Remove-Item $pfx -Force -ErrorAction SilentlyContinue }
+
+          & $signtool sign /fd SHA256 /sha1 $env:THUMBPRINT /td SHA256 $bundle
+          if ($LASTEXITCODE -ne 0) { throw "signtool failed ($LASTEXITCODE)" }
+
+          "path=$bundle"                 | Out-File -Append $env:GITHUB_OUTPUT
+          "name=$(Split-Path $bundle -Leaf)" | Out-File -Append $env:GITHUB_OUTPUT
+
+      - name: Attach bundle to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          gh release upload '${{ steps.tag.outputs.tag }}' '${{ steps.bundle.outputs.path }}' `
+            --clobber --repo '${{ github.repository }}'
+
+      - name: Setup Microsoft Store CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.3
+
+      - name: Configure Store credentials
+        shell: pwsh
+        run: |
+          msstore reconfigure `
+            --tenantId   '${{ secrets.AZURE_TENANT_ID }}' `
+            --sellerId   '${{ secrets.SELLER_ID }}' `
+            --clientId   '${{ secrets.AZURE_AD_CLIENT_ID }}' `
+            --clientSecret '${{ secrets.AZURE_AD_CLIENT_SECRET }}'
+
+      - name: Publish bundle + release notes to Store
+        shell: pwsh
+        env:
+          PRODUCT_ID: ${{ env.STORE_PRODUCT_ID }}
+          BUNDLE: ${{ steps.bundle.outputs.path }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # Clear any leftover pending draft so publish starts from the live submission.
+          msstore submission delete $env:PRODUCT_ID --no-confirm 2>$null
+          $global:LASTEXITCODE = 0
+
+          # Clone the live submission, upload the bundle, but hold the commit.
+          msstore publish $env:BUNDLE -id $env:PRODUCT_ID --noCommit
+          if ($LASTEXITCODE -ne 0) { throw "msstore publish failed ($LASTEXITCODE)" }
+
+          # Pull the draft, splice in WHATS_NEW.md, and retire any non-bundle
+          # (loose .msix) packages the clone carried over. The PendingDelete loop
+          # auto-handles the one-time .msix -> .msixbundle migration and is a no-op
+          # on every run after that (bundle -> bundle).
+          $out  = msstore submission get $env:PRODUCT_ID | Out-String
+          $s    = $out.IndexOf('{'); $e = $out.LastIndexOf('}')
+          if ($s -lt 0 -or $e -le $s) { throw "Could not parse submission JSON from msstore output" }
+          $sub  = $out.Substring($s, $e - $s + 1) | ConvertFrom-Json
+
+          $sub.Listings.'en-us'.BaseListing.ReleaseNotes = (Get-Content -Raw $env:WHATS_NEW_PATH).TrimEnd()
+          foreach ($p in $sub.ApplicationPackages) {
+            if ($p.FileName -notlike '*.msixbundle') { $p.FileStatus = 'PendingDelete' }
+          }
+
+          $sub | ConvertTo-Json -Depth 100 | Set-Content -Path patched.json -Encoding utf8
+          msstore submission updateMetadata $env:PRODUCT_ID (Get-Content -Raw patched.json)
+          if ($LASTEXITCODE -ne 0) { throw "updateMetadata failed ($LASTEXITCODE)" }
+
+          msstore submission publish $env:PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) { throw "submission publish failed ($LASTEXITCODE)" }
+          Write-Host "Submitted $env:BUNDLE to the Store (product $env:PRODUCT_ID)."

--- a/HoobiBitwardenCommandPaletteExtension/Assets/WHATS_NEW.md
+++ b/HoobiBitwardenCommandPaletteExtension/Assets/WHATS_NEW.md
@@ -1,0 +1,12 @@
+What's new in version 1.11.0:
+- Install Bitwarden CLI directly from Command Palette
+- Organization vault tags and search by Organization name
+- Added enter to submit workaround on login/unlock pages (still waiting on upstream fix)
+- Fix for multiple MFA methods, TOTP timeouts
+- Fix for custom CLI path being ignored
+
+... and various other fixes
+
+Thank you for using the Command Palette Extension for Bitwarden!
+
+Full changelog: https://github.com/hoobio/command-palette-bitwarden/blob/main/CHANGELOG.md

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -14,6 +14,7 @@ A free, open-source replacement for 1Password Quick Access, built for the [Power
 - [Settings](Settings)
 - [Vault Item Actions](Vault-Item-Actions)
 - [Architecture](Architecture)
+- [Release & Store Publishing](Release-and-Store-Publishing)
 
 ## Feature Overview
 

--- a/docs/Release-and-Store-Publishing.md
+++ b/docs/Release-and-Store-Publishing.md
@@ -1,0 +1,31 @@
+# Release & Store Publishing
+
+How a tagged release reaches the Microsoft Store.
+
+## Pipeline overview
+
+1. `build.yaml` (release-please) cuts a release, builds + signs the per-architecture `.msix`/`.msi`, and attaches them to the GitHub release.
+2. Publishing the release fires `release: published`, which triggers [`store-publish.yml`](../.github/workflows/store-publish.yml).
+3. `store-publish.yml` downloads the per-arch `.msix` release assets, combines them into a single signed `.msixbundle`, attaches that bundle to the release, and submits it to the Store along with the listing's "What's new" notes.
+
+A bundle is used for the Store because the `msstore` CLI uploads exactly one package file per submission and matches existing packages by extension; two loose `.msix` can't both update one submission, but one `.msixbundle` can.
+
+## "What's new" notes
+
+The Store listing's release notes come from [`HoobiBitwardenCommandPaletteExtension/Assets/WHATS_NEW.md`](../HoobiBitwardenCommandPaletteExtension/Assets/WHATS_NEW.md). Edit it before tagging a release; the workflow reads it at the release tag and writes it to the submission's `Listings.en-us.BaseListing.ReleaseNotes`.
+
+## Required configuration
+
+Repository **secrets**: `AZURE_TENANT_ID`, `AZURE_AD_CLIENT_ID`, `AZURE_AD_CLIENT_SECRET`, `SELLER_ID` (the Entra app registration must be added to Partner Center → User management with the **Manager** role), plus the existing `SIGNING_CERTIFICATE` / `SIGNING_CERTIFICATE_PASSWORD`.
+
+Repository **variable**: `SIGNING_CERT_THUMBPRINT`.
+
+Product ID (`9P5KS8T80MV3`) is hard-coded in the workflow `env`. GitHub Actions publishing is supported for **free** products only.
+
+## Manual re-run
+
+Re-publish any tag from the Actions tab: run **Publish to Microsoft Store** with the `tag` input (e.g. `v1.11.0`).
+
+## One-time migration note
+
+The first bundle submission has to retire the two loose `.msix` packages from the previous (manual) submissions. The workflow does this automatically: it marks every non-`.msixbundle` package `PendingDelete` before committing. On the first run, confirm in Partner Center that the committed submission contains only the `.msixbundle`. Every run after that is bundle-to-bundle and the cleanup step is a no-op.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -13,3 +13,4 @@
   - [Settings](Settings)
 - **Development**
   - [Architecture](Architecture)
+  - [Release & Store Publishing](Release-and-Store-Publishing)


### PR DESCRIPTION
Automates Store submission on release.

On `release: published` (prereleases skipped; manual re-run via `workflow_dispatch` + `tag`), `store-publish.yml`:
- downloads the per-arch `.msix` release assets and combines them into one signed `.msixbundle`
- attaches the bundle to the GitHub release
- submits the bundle to the Store with the `WHATS_NEW.md` release notes, retiring the legacy loose `.msix` packages on the first run

A bundle is required because the msstore CLI uploads one package per submission and matches existing packages by extension, so two loose `.msix` can't both update a single submission. `build.yaml` is untouched.

Also adds the tracked `WHATS_NEW.md` (source of the listing's "What's new") and a docs page.

First-run checks: confirm the release `.msixbundle` sideloads, and that the committed Store submission contains only the bundle. Requires the Entra app registration to hold the Manager role in Partner Center.
