### PR TITLE
fix: apply search typed while the vault is still loading

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/HoobiBitwardenCommandPaletteExtensionPage.cs
@@ -223,12 +223,35 @@ internal sealed partial class HoobiBitwardenCommandPaletteExtensionPage : Dynami
         }
         else
         {
-            _ = Task.Run(async () =>
-            {
-                IsLoading = true;
-                await _service.RefreshCacheAsync();
-            });
+            // Cache isn't loaded yet (cold start / warmup still running). The text
+            // is already recorded in _currentSearchText above; make sure it gets
+            // applied once the cache lands. Relying on the warmup's CacheUpdated
+            // alone is racy - it can rebuild the list a moment before this
+            // keystroke's text is recorded, leaving results unfiltered until the
+            // user types another character.
+            _ = Task.Run(ApplySearchWhenCacheReadyAsync);
         }
+    }
+
+    private async Task ApplySearchWhenCacheReadyAsync()
+    {
+        IsLoading = true;
+        // Await the in-flight warmup instead of firing a concurrent `bw list
+        // items`, which can hang the CLI when both run at once.
+#pragma warning disable VSTHRD003 // WarmupTask is a ThreadPool task; this runs on ThreadPool via Task.Run
+        try { await _service.WarmupTask.ConfigureAwait(false); } catch { }
+#pragma warning restore VSTHRD003
+        if (!_service.IsCacheLoaded)
+            await _service.RefreshCacheAsync().ConfigureAwait(false);
+
+        if (_handlingAction || _service.LastStatus != VaultStatus.Unlocked || !_service.IsCacheLoaded)
+            return;
+
+        // Re-apply whatever has been typed by now (read here, after the cache is
+        // ready, so it reflects the latest keystroke rather than a stale snapshot).
+        _currentItems = BuildListItems(Search(_currentSearchText));
+        IsLoading = false;
+        RaiseItemsChanged();
     }
 
     private void OnSearchDebounceTick(object? _)


### PR DESCRIPTION
## Problem

Typing into the search box while the vault is still loading (cold start / warmup) left the results unfiltered. The filter only kicked in once the vault finished loading **and** the user typed another character.

## Cause

`UpdateSearchText`'s loading branch (cache not loaded yet) recorded the typed text but never re-applied *that keystroke's* text once the cache landed. It relied entirely on the warmup's `CacheUpdated`/`WarmupCompleted` events to rebuild the list, and those fire on a separate thread. When a cache-load event won the race against the keystroke being recorded, the list rendered unfiltered with nothing to correct it until the next keystroke hit the (now cache-loaded) debounce path.

## Fix

The loading branch now awaits the in-flight warmup, then re-reads `_currentSearchText` and rebuilds **after** the cache is ready, so the result reflects the latest text regardless of event ordering. Awaiting `WarmupTask` (instead of the old fire-and-forget `RefreshCacheAsync`) also avoids a redundant concurrent `bw list items`.

## Testing

- Builds clean (Debug / x64 / Dev) against `main`.
- `Pages/` is coverage-excluded (UI-only), so no unit test added.