### PR TITLE
ci: add stale bot for inactive issues and PRs

### DIFF
--- a/.github/workflows/needs-info-reset.yaml
+++ b/.github/workflows/needs-info-reset.yaml
@@ -1,0 +1,22 @@
+name: Clear need-more-info on author reply
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  clear:
+    if: >
+      !github.event.issue.pull_request &&
+      github.event.comment.user.login == github.event.issue.user.login &&
+      contains(github.event.issue.labels.*.name, 'need-more-info')
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --remove-label need-more-info --repo "$REPO"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,33 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned,security
+          stale-issue-message: >
+            This issue has been inactive for 30 days and is now marked stale.
+            Remove the stale label or comment to keep it open, otherwise it will
+            be closed in 7 days.
+          stale-pr-message: >
+            This PR has been inactive for 30 days and is now marked stale.
+            Remove the stale label or comment to keep it open, otherwise it will
+            be closed in 7 days.
+          close-issue-message: Closed as stale after 7 days of inactivity. Reopen if still relevant.
+          close-pr-message: Closed as stale after 7 days of inactivity. Reopen if still relevant.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
           days-before-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: pinned,security
+          exempt-issue-labels: pinned,security,need-more-info
           exempt-pr-labels: pinned,security
           stale-issue-message: >
             This issue has been inactive for 30 days and is now marked stale.
@@ -31,3 +31,19 @@ jobs:
             be closed in 7 days.
           close-issue-message: Closed as stale after 7 days of inactivity. Reopen if still relevant.
           close-pr-message: Closed as stale after 7 days of inactivity. Reopen if still relevant.
+
+  awaiting-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: need-more-info
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: stale
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            We're waiting on more information to look into this (see the
+            need-more-info label). If there's no reply within 7 days this will
+            be closed. Just comment to keep it open.
+          close-issue-message: Closed because the requested information wasn't provided. Comment to reopen.


### PR DESCRIPTION
Adds a daily `actions/stale@v9` workflow.

- 30 days inactivity -> `stale` label
- a further 7 days -> closed
- exempts `pinned` and `security` labels (`pinned` created and applied to open feature items)
- manual `workflow_dispatch` trigger for testing