### PR TITLE
fix: stop self-hosted vaults requesting icons from Bitwarden cloud

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/BitwardenCliServiceMockedTests.cs
@@ -458,6 +458,26 @@ public class BitwardenCliServiceMockedTests
   }
 
   [Fact]
+  public async Task SetServerUrl_MarksServerUrlResolved()
+  {
+    var (svc, factory) = CreateService();
+    factory.Enqueue(new FakeCliProcess(stdout: "Saved setting `config`.\n", exitCode: 0));
+    BitwardenCliService.ResetStaticState();
+    Assert.False(BitwardenCliService.ServerUrlResolved);
+    await svc.SetServerUrlAsync(new ServerConfig("https://vault.example.com"));
+    Assert.True(BitwardenCliService.ServerUrlResolved);
+  }
+
+  [Fact]
+  public void ResetStaticState_ClearsServerUrlResolved()
+  {
+    BitwardenCliService.ResetStaticState();
+    Assert.False(BitwardenCliService.ServerUrlResolved);
+    Assert.Null(BitwardenCliService.ServerUrl);
+    Assert.Null(BitwardenCliService.IconsUrl);
+  }
+
+  [Fact]
   public async Task SetServerUrl_SetsStatusToUnauthenticated()
   {
     var (svc, factory) = CreateService();

--- a/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
+++ b/HoobiBitwardenCommandPaletteExtension.Tests/VaultItemHelperTests.cs
@@ -5,6 +5,9 @@ using HoobiBitwardenCommandPaletteExtension.Services;
 
 namespace HoobiBitwardenCommandPaletteExtension.Tests;
 
+// Shares BitwardenCliService's static server-resolution state with the other
+// collection members, so these must not run in parallel with them.
+[Collection("SessionStore")]
 public class VaultItemHelperTests
 {
   [Theory]
@@ -41,6 +44,31 @@ public class VaultItemHelperTests
   {
     var item = new BitwardenItem { Type = BitwardenItemType.Card, CardBrand = "Visa" };
     var icon = VaultItemHelper.GetIcon(item, showWebsiteIcons: false);
+    Assert.Equal("\uE8C7", icon.Dark.Icon);
+  }
+
+  // Issue #194: before `bw status` resolves the server, a self-hosted vault must
+  // not fall back to Bitwarden's cloud icon hosts. A glyph here proves no icon
+  // was queued - a queued icon returns the empty-string fallback instead.
+  [Fact]
+  public void GetIcon_Login_ServerUnresolved_ReturnsGlobeGlyphWithoutQueueing()
+  {
+    BitwardenCliService.ResetStaticState();
+    var item = new BitwardenItem
+    {
+      Type = BitwardenItemType.Login,
+      Uris = [new ItemUri("https://example.com", UriMatchType.Default)],
+    };
+    var icon = VaultItemHelper.GetIcon(item, showWebsiteIcons: true);
+    Assert.Equal("\uE774", icon.Dark.Icon);
+  }
+
+  [Fact]
+  public void GetIcon_Card_ServerUnresolved_ReturnsCardGlyphWithoutQueueing()
+  {
+    BitwardenCliService.ResetStaticState();
+    var item = new BitwardenItem { Type = BitwardenItemType.Card, CardBrand = "Visa" };
+    var icon = VaultItemHelper.GetIcon(item, showWebsiteIcons: true);
     Assert.Equal("\uE8C7", icon.Dark.Icon);
   }
 

--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -482,6 +482,9 @@ internal static partial class VaultItemHelper
 
   internal static IconInfo GetCardBrandIcon(string brand, int priority = int.MaxValue)
   {
+    if (!BitwardenCliService.ServerUrlResolved)
+      return new IconInfo("\uE8C7");
+
     var isDark = IsDarkTheme();
     var slug = SanitizeBrandSlug(brand);
     var theme = isDark ? "dark" : "light";
@@ -500,6 +503,14 @@ internal static partial class VaultItemHelper
 
     var serverUrl = BitwardenCliService.ServerUrl;
     var iconsUrl = BitwardenCliService.IconsUrl;
+
+    // Until `bw status` has resolved the server, an empty ServerUrl is unknown
+    // rather than cloud. Show a generic icon instead of guessing: on a
+    // self-hosted vault, guessing leaks hostnames to icons.bitwarden.net.
+    // FetchServerUrlAsync re-raises StatusChanged, which rebuilds the list.
+    if (string.IsNullOrEmpty(iconsUrl) && !BitwardenCliService.ServerUrlResolved)
+      return new IconInfo("\uE774");
+
     string iconBase;
     if (!string.IsNullOrEmpty(iconsUrl))
       iconBase = iconsUrl;

--- a/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Services/BitwardenCliService.cs
@@ -69,10 +69,17 @@ internal sealed partial class BitwardenCliService
   internal static string? ServerUrl { get; private set; }
   internal static string? IconsUrl { get; private set; }
 
+  // False until `bw status` has reported which server the vault is on. A null
+  // ServerUrl means "Bitwarden cloud" once resolved, but "not known yet" before
+  // that, and callers that pick a host must not conflate the two - guessing
+  // cloud sends self-hosted vault hostnames to icons.bitwarden.net (issue #194).
+  internal static bool ServerUrlResolved { get; private set; }
+
   internal static void ResetStaticState()
   {
     ServerUrl = null;
     IconsUrl = null;
+    ServerUrlResolved = false;
   }
 
   // Resolution order: the user's explicit override always wins (even if broken,
@@ -511,6 +518,7 @@ internal sealed partial class BitwardenCliService
       var json = JsonNode.Parse(output);
       var rawServerUrl = json?["serverUrl"]?.GetValue<string>()?.TrimEnd('/');
       ServerUrl ??= rawServerUrl;
+      ServerUrlResolved = true;
       var status = json?["status"]?.GetValue<string>();
       var result = status == "unauthenticated" ? VaultStatus.Unauthenticated : VaultStatus.Locked;
       var safeServer = SanitizeServerUrl(rawServerUrl);
@@ -736,7 +744,7 @@ internal sealed partial class BitwardenCliService
 
   private async Task FetchServerUrlAsync()
   {
-    if (ServerUrl != null)
+    if (ServerUrlResolved)
       return;
 
     try
@@ -745,6 +753,11 @@ internal sealed partial class BitwardenCliService
       var url = JsonNode.Parse(output)?["serverUrl"]?.GetValue<string>()?.TrimEnd('/');
       if (!string.IsNullOrWhiteSpace(url))
         ServerUrl = url;
+      ServerUrlResolved = true;
+
+      // Items rendered while the server was still unknown show a generic icon.
+      // Re-raise so the list rebuilds and queues icons against the right host.
+      StatusChanged?.Invoke();
     }
     catch (Exception ex)
     {
@@ -1067,6 +1080,7 @@ internal sealed partial class BitwardenCliService
           try { process.Kill(true); } catch { }
           ServerUrl = config.BaseUrl.TrimEnd('/');
           IconsUrl = config.IconsUrl?.TrimEnd('/');
+          ServerUrlResolved = true;
           SetStatus(VaultStatus.Unauthenticated);
           StatusChanged?.Invoke();
           return null;

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -18,7 +18,7 @@ Open settings from the gear icon in the vault browser. All settings take effect 
 |---|---|
 | **Type** | Toggle |
 | **Default** | On |
-| **Description** | Download and display website favicons for login items. Icons are fetched from `icons.bitwarden.net` (cloud) or your self-hosted server's `/icons/` endpoint, then cached locally for 7 days. Disable for privacy; a generic icon will be shown instead. See [Bitwarden's website icon documentation](https://bitwarden.com/help/website-icons/) for more details. |
+| **Description** | Download and display website favicons for login items. Icons are fetched from `icons.bitwarden.net` (cloud) or your self-hosted server's `/icons/` endpoint, then cached locally for 7 days. Disable for privacy; a generic icon will be shown instead. Right after the vault unlocks, items show a generic icon until the extension has confirmed which server the vault is on, so a self-hosted vault never requests icons from Bitwarden's cloud. See [Bitwarden's website icon documentation](https://bitwarden.com/help/website-icons/) for more details. |
 
 ### Auto-Lock Timeout
 


### PR DESCRIPTION
## Summary

Fixes #194. A self-hosted vault was sending its item hostnames to `icons.bitwarden.net` (and card brand images to `vault.bitwarden.com`), both on Bitwarden's Fastly edge at 199.232.193.91.

The icon host is picked from the static `BitwardenCliService.ServerUrl`, which starts null on every process launch and is only filled by a fire-and-forget `bw status` kicked off when the vault unlocks. Items rendered before that call returns hit the `string.IsNullOrEmpty(serverUrl)` branch, which treats "not known yet" as "cloud". On a self-hosted setup that leaks vault hostnames to a third party, and the 5 minute negative cache means it retries rather than going quiet.

## Changes

- Track resolution state separately from the value: new `ServerUrlResolved` flag set by `bw status`, by `SetServerUrlAsync`, and cleared by `ResetStaticState`
- `GetFaviconIcon` and `GetCardBrandIcon` return a generic glyph and queue nothing until the server is known, rather than defaulting to the cloud hosts. An explicit icons URL override still wins immediately
- `FetchServerUrlAsync` re-raises `StatusChanged` once resolved so the list rebuilds and icons load against the correct host
- Moved `VaultItemHelperTests` into the `SessionStore` collection, since it now asserts against the same static state the service tests mutate

## Testing

- [x] Unit tests added/updated
- [x] Manual testing with PowerToys Command Palette
- [x] Existing tests pass (`dotnet test -p:Platform=x64`)

515 passed, 0 failed.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
- [x] Code builds without warnings (`dotnet build -c Release -p:Platform=x64`)
- [x] Changed `.cs` files meet the 50% coverage threshold
- [x] Wiki docs updated (if behavior/settings changed)
