### PR TITLE
fix: use full https://vault.bitwarden.eu URL for the EU preset

### DIFF
--- a/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Helpers/VaultItemHelper.cs
@@ -50,7 +50,7 @@ internal static partial class VaultItemHelper
     BitwardenItemType.SshKey when IsValidSshHost(item.SshHost) =>
       () => { try { Process.Start(new ProcessStartInfo("ssh", item.SshHost!) { UseShellExecute = false }); } catch { } },
     _ => () => Process.Start(new ProcessStartInfo(
-      $"{BitwardenCliService.ServerUrl}/#/vault?itemId={Uri.EscapeDataString(item.Id)}")
+      $"{GetVaultBaseUrl()}/#/vault?itemId={Uri.EscapeDataString(item.Id)}")
     { UseShellExecute = true }),
   };
 
@@ -515,7 +515,7 @@ internal static partial class VaultItemHelper
   }
 
   internal static OpenUrlCommand BuildOpenInWebVaultCommand(string itemId) =>
-    new($"{BitwardenCliService.ServerUrl}/#/vault?itemId={Uri.EscapeDataString(itemId)}")
+    new($"{GetVaultBaseUrl()}/#/vault?itemId={Uri.EscapeDataString(itemId)}")
     {
       Name = "View in Web Vault",
     };

--- a/HoobiBitwardenCommandPaletteExtension/Pages/SetServerPage.cs
+++ b/HoobiBitwardenCommandPaletteExtension/Pages/SetServerPage.cs
@@ -87,12 +87,13 @@ internal sealed partial class SetServerPage : DynamicListPage
       cloudItem.Tags = [new Tag("Current") { Background = ColorHelpers.FromRgb(0x3E, 0x7C, 0xCF) }];
     items.Add(cloudItem);
 
-    // EU preset
-    var euItem = new ListItem(new AnonymousCommand(() => _onSubmit?.Invoke(new ServerConfig("bitwarden.eu")))
+    // EU preset. The CLI only special-cases "bitwarden.com" (resets to the US region); any other
+    // value is passed through as a self-hosted base URL, so the EU host needs its full URL.
+    var euItem = new ListItem(new AnonymousCommand(() => _onSubmit?.Invoke(new ServerConfig("https://vault.bitwarden.eu")))
     { Name = "Select", Result = CommandResult.GoBack() })
     {
       Title = "Bitwarden EU",
-      Subtitle = "bitwarden.eu",
+      Subtitle = "vault.bitwarden.eu",
       Icon = new IconInfo("\uE774"),
     };
     if (preset == "bitwarden.eu")

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -40,4 +40,4 @@ dotnet build -c Debug -p:Platform=x64
 
 ## Setting Your Server
 
-If you use a self-hosted Bitwarden server, select **Set Bitwarden Server** from the vault browser and enter your server URL. The default is `https://vault.bitwarden.com`.
+Select **Set Bitwarden Server** from the vault browser to pick a preset (**Bitwarden Cloud** for `bitwarden.com`, **Bitwarden EU** for `https://vault.bitwarden.eu`) or type a self-hosted server URL. The default is `https://vault.bitwarden.com`.


### PR DESCRIPTION
Fixes #191

The Bitwarden CLI only special-cases `bitwarden.com` in `config server` (it resets to the US region defaults). Any other value is passed through verbatim as a self-hosted base URL, so the **Bitwarden EU** preset submitting the bare host `bitwarden.eu` left the CLI with a schemeless base URL and every request failed to reach the endpoint.

Source: [config.command.ts](https://github.com/bitwarden/clients/blob/main/apps/cli/src/platform/commands/config.command.ts) - `url = url === "null" || url === "bitwarden.com" || url === "https://bitwarden.com" ? null : url;`

- EU preset now submits `https://vault.bitwarden.eu` (the URL Bitwarden's docs specify), and the subtitle shows the real host
- "View in Web Vault" links now go through the existing `GetVaultBaseUrl()` normaliser, so a bare preset host (`bitwarden.com`) can't produce a schemeless link either
- Getting-Started doc mentions both presets

Existing EU users need to re-select the preset once to pick up the corrected URL.

Verified: `dotnet build -c Release -p:Platform=x64` clean, 511/511 tests pass.
